### PR TITLE
Fix implementation of `__hash__` for HashModel and variants

### DIFF
--- a/boink/pythonizors/pythonize_hashing.py
+++ b/boink/pythonizors/pythonize_hashing.py
@@ -79,5 +79,5 @@ def pythonize_boink_hashing(klass, name):
             klass.__ge__ = lambda self, other: self.value >= other.value
             klass.__ne__ = lambda self, other: self.value != other.value
             klass.__repr__ = klass.__str__
-
+            klass.__hash__ = lambda self: self.value
 

--- a/boink/pythonizors/pythonize_hashing.py
+++ b/boink/pythonizors/pythonize_hashing.py
@@ -71,7 +71,7 @@ def pythonize_boink_hashing(klass, name):
 
         is_inst, _ = is_template_inst(name, check_name)
         if is_inst:
-            
+
             klass.value = property(klass.value)
             klass.__lt__ = lambda self, other: self.value < other.value
             klass.__le__ = lambda self, other: self.value <= other.value
@@ -79,5 +79,4 @@ def pythonize_boink_hashing(klass, name):
             klass.__ge__ = lambda self, other: self.value >= other.value
             klass.__ne__ = lambda self, other: self.value != other.value
             klass.__repr__ = klass.__str__
-            klass.__hash__ = lambda self: self.value
-
+            klass.__hash__ = lambda self: hash(self.value)

--- a/include/boink/hashing/canonical.hh
+++ b/include/boink/hashing/canonical.hh
@@ -34,13 +34,18 @@ struct HashModel {
 
     value_type hash;
 
-    HashModel(value_type hash)
+    HashModel(const value_type hash)
         : hash(hash)
     {
     }
 
     HashModel()
         : hash(std::numeric_limits<value_type>::max())
+    {
+    }
+
+    HashModel(const HashModel& other)
+        : hash(other.hash)
     {
     }
 
@@ -93,15 +98,21 @@ struct CanonicalModel {
     value_type fw_hash, rc_hash;
 
     CanonicalModel()
-        : fw_hash(),
-          rc_hash()
+        : fw_hash(std::numeric_limits<value_type>::max()),
+          rc_hash(std::numeric_limits<value_type>::max())
     {
     }
 
-    CanonicalModel(value_type fw,
-                   value_type rc)
+    CanonicalModel(const value_type fw,
+                   const value_type rc)
         : fw_hash(fw),
           rc_hash(rc)
+    {
+    }
+
+    CanonicalModel(const CanonicalModel& other)
+        : fw_hash(other.fw_hash),
+          rc_hash(other.rc_hash)
     {
     }
 
@@ -183,7 +194,17 @@ struct WmerModel<HashType<ValueType>, MinimizerType> {
     {
     }
 
-    WmerModel() {}
+    WmerModel()
+        : hash(),
+          minimizer()
+    {
+    }
+
+    WmerModel(const WmerModel& other)
+        : hash(other.hash),
+          minimizer(other.minimizer)
+    {
+    }
 
     const value_type value() const {
         return hash.value();
@@ -261,6 +282,12 @@ struct KmerModel<HashType<ValueType, Extras...>> {
 	KmerModel()
         : hash(),
           kmer(0, ' ')
+    {
+    }
+
+    KmerModel(const KmerModel& other)
+        : hash(other.hash),
+          kmer(other.kmer)
     {
     }
 
@@ -345,7 +372,13 @@ struct ShiftModel<HashType<ValueType, Extras...>, Direction> {
     }
 
     ShiftModel()
-        : symbol('\0')
+        : hash(),
+          symbol('\0')
+    {
+    }
+
+    ShiftModel(const ShiftModel& other)
+        : ShiftModel(other.hash, other.symbol)
     {
     }
 
@@ -405,15 +438,22 @@ struct Partitioned {
     value_type v;
     uint64_t   partition;
 
-    Partitioned(value_type& v,
-                uint64_t   partition)
+    Partitioned(const value_type& v,
+                const uint64_t   partition)
         : v(v),
           partition(partition)
     {
     }
     
     Partitioned()
-        : partition(std::numeric_limits<uint64_t>::max())
+        : v(),
+          partition(std::numeric_limits<uint64_t>::max())
+    {
+    }
+
+    Partitioned(const Partitioned& other)
+        : v(other.v),
+          partition(other.partition)
     {
     }
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 testpaths = tests
-addopts = -v --ignore=boink/tests/test_partitioning.py --ignore=boink/tests/test_stats.py --benchmark-autosave
+addopts = -v --benchmark-autosave --randomly-dont-reorganize

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 plotille
+pytest-randomly

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -64,23 +64,27 @@ def test_rolling_hash(hasher, ksize):
         assert h.value == e
 
 
-@using(ksize=7, length=20000)
-@pytest.mark.parametrize
+@using(ksize=21, length=10000)
 def test_hashing_models_hash(hasher, ksize, random_sequence):
     '''test that __hash__ on HashModel and CanonicalModel
     yields the value attribute.
     '''
 
     seq = random_sequence()
+    seq += hasher.alphabet.reverse_complement(seq)
+
     hash_set = set()
     value_set = set()
-    for kmer in kmers(sequence, ksize):
+    for kmer in kmers(seq, ksize):
         h = hasher.hash(kmer)
-        assert hash(h) == h.value
-        hash_set.insert(h)
-        value_set.insert(h.value)
+        # doing hash(h.value) is on purpose! because CPython silently transforms
+        # the result of __hash__ into a 62 bit signed range... sigh
+        assert hash(h) == hash(h.value), (h, h.value)
+        hash_set.add(h)
+        value_set.add(h.value)
     
-    assert hash_set == value_set
+    assert len(hash_set) == len(value_set)
+    assert sorted((h.value for h in hash_set)) == sorted((h for h in value_set))
 
 
 @using(ksize=27)

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -64,8 +64,30 @@ def test_rolling_hash(hasher, ksize):
         assert h.value == e
 
 
+@using(ksize=7, length=20000)
+@pytest.mark.parametrize
+def test_hashing_models_hash(hasher, ksize, random_sequence):
+    '''test that __hash__ on HashModel and CanonicalModel
+    yields the value attribute.
+    '''
+
+    seq = random_sequence()
+    hash_set = set()
+    value_set = set()
+    for kmer in kmers(sequence, ksize):
+        h = hasher.hash(kmer)
+        assert hash(h) == h.value
+        hash_set.insert(h)
+        value_set.insert(h.value)
+    
+    assert hash_set == value_set
+
+
 @using(ksize=27)
 def test_rolling_nonvolatile_hash(hasher, ksize):
+    '''test that hasher.hash([str]) on an instance does not
+    change the hasher state.
+    '''
     seq = 'TCACCTGTGTTGTGCTACTTGCGGCGC'
 
     original = hasher.hash_base(seq)


### PR DESCRIPTION
Previously, `CanonicalModel` had incorrect behaviors in python containers, because opposite strand k-mers of the same canonical value where being considered different objects. Fixes previous CI failures on `test_dbg.test_n_unique`.