### PR TITLE
An Example Notebook for dBG Traversal and k-mer Hashing

### DIFF
--- a/boink/dbg.py
+++ b/boink/dbg.py
@@ -30,7 +30,7 @@ def get_graph_args(parser):
     group = parser.add_argument_group('dBG')
     group.add_argument('-K', '--ksize', type=int, default=31)
     group.add_argument('--hasher', choices=list(hasher_types.keys()),
-                       default='RollingHashShifter')
+                       default='LemireShifterPolicy')
 
     get_storage_args(parser)
 

--- a/boink/hashing.py
+++ b/boink/hashing.py
@@ -1,8 +1,8 @@
 from boink import libboink
 
 
-typenames = [(libboink.hashing.FwdRollingShifter, 'FwdRollingShifter'),
-             (libboink.hashing.CanRollingShifter, 'CanRollingShifter'),
+typenames = [(libboink.hashing.FwdLemireShifter, 'FwdLemireShifter'),
+             (libboink.hashing.CanLemireShifter, 'CanLemireShifter'),
              (libboink.hashing.FwdUnikmerShifter, 'FwdUnikmerShifter'),
              (libboink.hashing.CanUnikmerShifter, 'CanUnikmerShifter')]
 types = [_type for _type, _name in typenames]

--- a/boink/pythonizors/pythonize_dbg.py
+++ b/boink/pythonizors/pythonize_dbg.py
@@ -40,12 +40,22 @@ def pythonize_boink(klass, name):
                 return func(self)
             return _get
 
+        def wrap_vector_ret(func):
+            def wrapped(self, *args, **kwargs):
+                return [item for item in func(self, *args, **kwargs)]
+            return wrapped
+
         klass.add = add
         klass.get_hash = wrap_get(klass.get)
         klass.get = wrap_query(klass.query)
         klass.left_degree = left_degree
         klass.right_degree = right_degree
         klass.shallow_clone = shallow_clone
-        klass.hashes = hashes 
+        klass.hashes = hashes
 
+        klass.left_extensions = wrap_vector_ret(klass.left_extensions)
+        klass.right_extensions = wrap_vector_ret(klass.right_extensions)
+        #klass.filter_nodes = wrap_vector_ret(klass.filter_nodes)
+        #klass.in_neighbors = wrap_vector_ret(klass.in_neighbors)
+        #klass.out_neighbors = wrap_vector_ret(klass.out_neighbors)
 

--- a/boink/pythonizors/pythonize_dbg.py
+++ b/boink/pythonizors/pythonize_dbg.py
@@ -45,6 +45,9 @@ def pythonize_boink(klass, name):
                 return [item for item in func(self, *args, **kwargs)]
             return wrapped
 
+        def wrap_walk(func):
+            pass
+
         klass.add = add
         klass.get_hash = wrap_get(klass.get)
         klass.get = wrap_query(klass.query)

--- a/boink/pythonizors/pythonize_hashing.py
+++ b/boink/pythonizors/pythonize_hashing.py
@@ -66,8 +66,8 @@ def pythonize_boink_hashing(klass, name):
 
         #set_typedef_attrs(klass, ['alphabet', 'hash_type', 'value_type', 'kmer_type'])
 
-    for check_name in ['HashModel', 'CanonicalModel', 'WmerModel',
-                       'KmerModel', 'ShiftModel', 'Partitioned']:
+    for check_name in ['Hash', 'Canonical', 'Wmer',
+                       'Kmer', 'Shift', 'Partitioned']:
 
         is_inst, _ = is_template_inst(name, check_name)
         if is_inst:

--- a/examples/dBG Traversal Demo.ipynb
+++ b/examples/dBG Traversal Demo.ipynb
@@ -18,8 +18,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.87 s, sys: 504 ms, total: 9.38 s\n",
-      "Wall time: 8.91 s\n"
+      "CPU times: user 8.8 s, sys: 455 ms, total: 9.25 s\n",
+      "Wall time: 8.78 s\n"
      ]
     }
    ],
@@ -77,7 +77,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.dBG<boink::storage::SparseppSetStorage,boink::hashing::HashShifter<boink::hashing::LemireShifterPolicy<boink::hashing::Canonical<unsigned long>,boink::DNA_SIMPLE> > > at 0x55dad4cb6820>"
+       "<class boink.boink.dBG<boink::storage::SparseppSetStorage,boink::hashing::HashShifter<boink::hashing::LemireShifterPolicy<boink::hashing::Canonical<unsigned long>,boink::DNA_SIMPLE> > > at 0x55d249d22110>"
       ]
      },
      "execution_count": 3,
@@ -331,7 +331,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.hashing.Canonical<unsigned long> at 0x55dad962f0a0>"
+       "<class boink.boink.hashing.Canonical<unsigned long> at 0x55d24e799d30>"
       ]
      },
      "execution_count": 12,
@@ -374,7 +374,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.hashing.HashShifter<boink::hashing::LemireShifterPolicy<boink::hashing::Canonical<unsigned long>,boink::DNA_SIMPLE> > at 0x55dad44ff7a0>"
+       "<class boink.boink.hashing.HashShifter<boink::hashing::LemireShifterPolicy<boink::hashing::Canonical<unsigned long>,boink::DNA_SIMPLE> > at 0x55d2495a0e50>"
       ]
      },
      "execution_count": 14,
@@ -403,7 +403,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class boink.boink.DNA_SIMPLE at 0x55dad509caa0>, ACGT, TGCA\n"
+      "<class boink.boink.DNA_SIMPLE at 0x55d24eb20710>, ACGT, TGCA\n"
      ]
     }
    ],
@@ -1188,6 +1188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "graph.set_cursor(anchor)\n",
     "walk = graph.walk_right()"
    ]
   },
@@ -1202,7 +1203,8 @@
     "* `head()`: The hash value of start.\n",
     "* `tail()`: The has value of the last extension (where we ended).\n",
     "* `to_string()`: The string representation of the walk, resulting from combining the start $k$-mer with the extensions (specialized for direction).\n",
-    "* `glue(Walk)`: The string resulting from glueing two walks of the opposite direction together.\n",
+    "* `glue(Walk)`: The string resulting from glueing two walks together, specialized on directions.\n",
+    "* `retreat_symbol()`: The symbol necessary to shift back left (or right) after moving to one of the end-state neighbors.\n",
     "\n",
     "In this case, we stopped on a forward decision node."
    ]
@@ -1215,7 +1217,7 @@
     {
      "data": {
       "text/plain": [
-       "(<Kmer hash=<Canonical fw=12736750171723927455 rc=8224377023565475682 sign=0> kmer=GTAGGAGGAATCACACCTCTGTGTTGTGCTA>,\n",
+       "(<Kmer hash=<Canonical fw=10388554386607035669 rc=1182107035245116275 sign=0> kmer=GGTAGGAGGAATCACACCTCTGTGTTGTGCT>,\n",
        " 1)"
       ]
      },
@@ -1256,7 +1258,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Shift hash=<Canonical fw=14637547382867799967 rc=7801055356572192737 sign=0> symbol=C direction=1>,\n",
+       "[<Shift hash=<Canonical fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>,\n",
+       " <Shift hash=<Canonical fw=14637547382867799967 rc=7801055356572192737 sign=0> symbol=C direction=1>,\n",
        " <Shift hash=<Canonical fw=13010390999111524039 rc=3221253690059650609 sign=0> symbol=T direction=1>,\n",
        " <Shift hash=<Canonical fw=12749353867514261335 rc=18060366745909523060 sign=1> symbol=T direction=1>,\n",
        " <Shift hash=<Canonical fw=10703243689465863068 rc=885851925541808064 sign=0> symbol=G direction=1>,\n",
@@ -1285,7 +1288,7 @@
     {
      "data": {
       "text/plain": [
-       "'GTAGGAGGAATCACACCTCTGTGTTGTGCTACTTGCGGCGC'"
+       "'GGTAGGAGGAATCACACCTCTGTGTTGTGCTACTTGCGGCGC'"
       ]
      },
      "execution_count": 48,
@@ -1333,7 +1336,144 @@
     "\n",
     "#### Traversin'\n",
     "\n",
-    "So now that we've walked a unitig, it's time to traverse to the rest of its neighbors. "
+    "So now that we've walked a unitig, it's time to traverse to the rest of its neighbors. The `Walk` object has `retreat_symbol` that will help usmove to each neighbor and then back to the decision node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "start: <Kmer hash=<Canonical fw=7170494598487408972 rc=16043475115312428656 sign=1> kmer=CACACCTCTGTGTTGTGCTACTTGCGGCGCA>\n",
+      "end state: 0\n",
+      "current hash: <Canonical fw=7170494598487408972 rc=16043475115312428656 sign=1>\n",
+      "walk string: CACACCTCTGTGTTGTGCTACTTGCGGCGCA\n",
+      "start: <Kmer hash=<Canonical fw=6462841522242458712 rc=8207629909326200059 sign=1> kmer=CACACCTCTGTGTTGTGCTACTTGCGGCGCC>\n",
+      "end state: 0\n",
+      "current hash: <Canonical fw=6462841522242458712 rc=8207629909326200059 sign=1>\n",
+      "walk string: CACACCTCTGTGTTGTGCTACTTGCGGCGCC\n"
+     ]
+    }
+   ],
+   "source": [
+    "prev = walk\n",
+    "for n in graph.out_neighbors():\n",
+    "    graph.shift_right(n.symbol)\n",
+    "    walk = graph.walk_right()\n",
+    "    print('start:', walk.start)\n",
+    "    print('end state:', walk.end_state)\n",
+    "    print('current hash:', graph.get_hash())\n",
+    "    print('walk string:', walk.to_string())\n",
+    "    # return to the decision_node\n",
+    "    graph.set_cursor(walk.start.kmer)\n",
+    "    graph.shift_left(prev.retreat_symbol())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, our two start positions were the two right neighbors, and each time our end state was `STOP_FWD` -- ie, a dead end. We then returned to the previous root by setting the cursor to the start of the walk and shifting left with the previous walk's retreat symbol.\n",
+    "\n",
+    "Both of these \"walks\" were single $k$-mers, but enh, they're still walks!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Bidrectional Walkin'\n",
+    "\n",
+    "Other than `walk_left` and `walk_right`, there's also plain old `walk`. This walks in both directions and returns the two walks as a tuple. We can demonstrate this by starting in the middle of unitig we assembled earlier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('GGTAGGAGGAATCACACCTCTGTGTTGTGCTACTTGCGGCGC', 42)"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prev.to_string(), len(prev.to_string())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seed = prev.to_string()[5:5+K]\n",
+    "lwalk, rwalk = graph.walk(seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<Kmer hash=<Canonical fw=10703243689465863068 rc=885851925541808064 sign=0> kmer=GAGGAATCACACCTCTGTGTTGTGCTACTTG> 0\n",
+      "GGTAGGAGGAATCACACCTCTGTGTTGTGCTACTTG\n",
+      "<Kmer hash=<Canonical fw=10703243689465863068 rc=885851925541808064 sign=0> kmer=GAGGAATCACACCTCTGTGTTGTGCTACTTG> 1\n",
+      "GAGGAATCACACCTCTGTGTTGTGCTACTTGCGGCGC\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(lwalk.start, lwalk.end_state)\n",
+    "print(lwalk.to_string())\n",
+    "print(rwalk.start, rwalk.end_state)\n",
+    "print(rwalk.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All fits together: `lwalk` has an end state of `STOP_FWD`, as it hit a dead-end in its direction of movement, and `rwalk` has an end state of `DECISION_FWD`, as it hit the decision node in its direction of movement. Each has the same start $k$-mer, and each has a `to_string()` result with that overlapping $k$-mer. If we want to combine them, we can use the `glue` method, which should give us back our original unitig."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert lwalk.glue(rwalk) == prev.to_string()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that, because `lwalk` and `rwalk` here are actually different types based on a template parameter for their direciton, their `glue` methods are specialized, and we can glue in the other order and still get the correct result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert rwalk.glue(lwalk) == prev.to_string()"
    ]
   }
  ],

--- a/examples/dBG Traversal Demo.ipynb
+++ b/examples/dBG Traversal Demo.ipynb
@@ -67,7 +67,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.dBG<boink::storage::SparseppSetStorage,boink::hashing::HashShifter<boink::hashing::RollingHashShifter<boink::hashing::CanonicalModel<unsigned long>,boink::DNA_SIMPLE> > > at 0x55d19c4bc740>"
+       "<class boink.boink.dBG<boink::storage::SparseppSetStorage,boink::hashing::HashShifter<boink::hashing::RollingHashShifter<boink::hashing::CanonicalModel<unsigned long>,boink::DNA_SIMPLE> > > at 0x562e1cdc3370>"
       ]
      },
      "execution_count": 3,
@@ -321,7 +321,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.hashing.CanonicalModel<unsigned long> at 0x55d1a0d98e90>"
+       "<class boink.boink.hashing.CanonicalModel<unsigned long> at 0x562e21721660>"
       ]
      },
      "execution_count": 12,
@@ -364,7 +364,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.hashing.HashShifter<boink::hashing::RollingHashShifter<boink::hashing::CanonicalModel<unsigned long>,boink::DNA_SIMPLE> > at 0x55d19bd41830>"
+       "<class boink.boink.hashing.HashShifter<boink::hashing::RollingHashShifter<boink::hashing::CanonicalModel<unsigned long>,boink::DNA_SIMPLE> > at 0x562e1c653b20>"
       ]
      },
      "execution_count": 14,
@@ -393,7 +393,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class boink.boink.DNA_SIMPLE at 0x55d19cef69b0>, ACGT, TGCA\n"
+      "<class boink.boink.DNA_SIMPLE at 0x562e21ae2c00>, ACGT, TGCA\n"
      ]
     }
    ],
@@ -745,7 +745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -847,7 +847,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -856,7 +856,7 @@
        "[(7847775928338814768, 'A')]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -884,7 +884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -893,7 +893,7 @@
        "<CanonicalModel fw=7847775928338814768 rc=11167344157054741611 sign=1>"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -906,16 +906,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "([(84412478834819436, 'A')], [(8312430231874395202, 'C')])"
+       "([], [(8312430231874395202, 'C')])"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -927,7 +927,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -956,7 +956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -966,7 +966,7 @@
        " <CanonicalModel fw=10388554386607035669 rc=1182107035245116275 sign=0>)"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -989,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -998,7 +998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -1008,7 +1008,7 @@
        " [<ShiftModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>])"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1056,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1065,7 +1065,7 @@
        "([(1182107035245116275, 'G')], [(7801055356572192737, 'C')])"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1083,7 +1083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -1094,7 +1094,7 @@
        " <CanonicalModel fw=10388554386607035669 rc=1182107035245116275 sign=0>)"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1114,7 +1114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -1123,7 +1123,7 @@
        "[8224377023565475682]"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1141,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -1152,7 +1152,7 @@
        " <CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0>)"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1174,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1199,7 +1199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -1209,7 +1209,7 @@
        " 1)"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1220,7 +1220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -1229,7 +1229,7 @@
        "(True, <CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0>)"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1240,7 +1240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -1258,7 +1258,7 @@
        " <ShiftModel hash=<CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0> symbol=C direction=1>]"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1269,7 +1269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -1278,7 +1278,7 @@
        "'GTAGGAGGAATCACACCTCTGTGTTGTGCTACTTGCGGCGC'"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1296,7 +1296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -1306,7 +1306,7 @@
        " <ShiftModel hash=<CanonicalModel fw=6462841522242458712 rc=8207629909326200059 sign=1> symbol=C direction=1>]"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/dBG Traversal Demo.ipynb
+++ b/examples/dBG Traversal Demo.ipynb
@@ -1,0 +1,1347 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The dBG: Hashing and Traversal\n",
+    "\n",
+    "This notebook demonstrates how to use boink's $k$-mer hashing and low level de Bruijn graph (dBG) traversal functionality. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import boink libraries\n",
+    "from boink import libboink\n",
+    "from boink.dbg import dBG, Graph\n",
+    "from boink.hashing import CanRollingShifter\n",
+    "from boink.storage import SparseppSetStorage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Building a dBG\n",
+    "\n",
+    "First. some explanation as to these classes. We have, from `boink.dbg`:\n",
+    "- `dBG`: This is the wrapped C++ dBG implementation. It is templated with a storage type and a hasher type; the storage type decides the underlying $k$-mer store, while the hashing type decides the hashing policy. Template class wrapped by `cppyy` are subscriptable, returning a complete class.\n",
+    "- `Graph`: A thin wrapper function around `dBG`. Called with the storage and hashing types, it returns a funtion that takes $K$, a tuple of storage arguments, and a tuple of hashing arguments. When calling the `dBG` constructor directly, one must pass in an already-constructed storage and hasher. Note that the latter method has uses as well, as it allows multiple `dBG`'s to share the same underling storage.\n",
+    "- `CanRollingShifter`: This is a hashing policy. It wraps [Lemire's rolling hash implementation](https://github.com/lemire/rollinghashcpp) and returns canonical hashes. The return type is `CanonicalModel<uint64_t>`, which has the attributes `fw_hash` and `rc_hash` for each strand (relative to the given sequence), along with the property `value` which returns the canonical hash.\n",
+    "- `SparseppSetStorage`: A $k$-mer store for the `dBG` using the lightweight [sparsepp](https://github.com/greg7mdp/sparsepp) hash table. `sparsepp` is significantly faster than `std::map` or `std::set`. Given that it's a regular hash table, this is an exact storage backend.\n",
+    "\n",
+    "\n",
+    "We construct a dBG as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = 31\n",
+    "hasher = CanRollingShifter(K)\n",
+    "storage = SparseppSetStorage.build()\n",
+    "graph = dBG[SparseppSetStorage, CanRollingShifter](storage, hasher)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we used the `.build()` method to get the storage. This is a C++ method that returns a `std::shared_ptr` owning the storage. The hasher is just going to get copied by the `dBG` in its constructor; it's only used as a prototype. The `dBG` uses the $K$ of the hasher.\n",
+    "\n",
+    "Because `graph` is a product of the `cppyy` wrapper, it has some special attributes. In particular, we can get its underlying C++ type:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<class boink.boink.dBG<boink::storage::SparseppSetStorage,boink::hashing::HashShifter<boink::hashing::RollingHashShifter<boink::hashing::CanonicalModel<unsigned long>,boink::DNA_SIMPLE> > > at 0x55d19c4bc740>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(graph)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's rather ugly, which is why working with these things from Python is nice!\n",
+    "\n",
+    "So, we now have a dBG with $K=31$. What can we do with it?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basics\n",
+    "\n",
+    "The most fundamental operations are probably adding new $k$-mers and asking about existing ones. For that, we have the `insert` and `query` methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "kmer = 'A' * K\n",
+    "\n",
+    "# returns True when the k-mer is new\n",
+    "graph.insert(kmer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Canonical hashing means the reverse complement k-mer reports as seen\n",
+    "graph.insert('T' * K)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We query similarly\n",
+    "graph.query(kmer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is also a method called `insert_and_query`, which does as it sounds: first inserts, then returns the post-insertion count. `SparseppSetStorage` is a presence-only backend (a set), so the reulst here will always be `1`; for backends that can count, this is more useful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.insert_and_query('A' * (K-1) + 'T')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can interrogate the dBG for global information, such as the number of unique $k$-mers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.n_unique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "dBG's with probabilistic storage backends support a false positive reporting function. Ours, however, is exact, and does not:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Template method resolution failed:\n  Failed to instantiate \"estimated_fp()\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-9-853026859349>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mgraph\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mestimated_fp\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m: Template method resolution failed:\n  Failed to instantiate \"estimated_fp()\""
+     ]
+    }
+   ],
+   "source": [
+    "graph.estimated_fp()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hashing Related"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`dBG`, eventually, derives from whichever hasher we gave it, and so supports its methods. This means we can, for example, hash an individual $k$-mer on it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CanonicalModel fw=1376280362712374913 rc=16264769942947757911 sign=1>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.hash(kmer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that only the canonical hash is stored in the underlying storage backend. We can access it through the `value` property:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1376280362712374913"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h = graph.hash(kmer)\n",
+    "h.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The hasher (which is an instance of `HashShifter<...>`) has a variety of `typedef`s associated with it, which are also exposed on the dBG and related classes. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<class boink.boink.hashing.CanonicalModel<unsigned long> at 0x55d1a0d98e90>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The basic hash type used \n",
+    "graph.hash_type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<KmerModel hash=<CanonicalModel fw=1376280362712374913 rc=16264769942947757911 sign=1> kmer=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Combines a k-mer string and its hash\n",
+    "graph.kmer_type\n",
+    "graph.kmer_type(graph.hash(kmer), kmer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<class boink.boink.hashing.HashShifter<boink::hashing::RollingHashShifter<boink::hashing::CanonicalModel<unsigned long>,boink::DNA_SIMPLE> > at 0x55d19bd41830>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# or the shifter and storage types\n",
+    "graph.shifter_type"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Additionally, there's the alphabet. `CanRollingShifter` is just a typedef that omits a template parameter that decides the alphabet of the dBG. It's statically accessible on the `dBG` (and the `HashShifter`) through the alphabet attribute, and has several useful statically defined methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class boink.boink.DNA_SIMPLE at 0x55d19cef69b0>, ACGT, TGCA\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(graph.alphabet, graph.alphabet.SYMBOLS, graph.alphabet.COMPLEMENTS, sep=', ')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.alphabet.reverse_complement(kmer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'C'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.alphabet.complement('G')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The HashShifter\n",
+    "\n",
+    "Though not *directly* related to performing dBG operations, it's useful to know a bit about how boink structures its hashing, and by extension, its neighbor-finding and traversal, under the hood.\n",
+    "\n",
+    "The most basic hasher is the `HashShifter<T>`, where `T` is a `ShiftPolicy<HashType, Alphabet>`. `ShiftPolicy` wraps the underlying hash functions to conform to a standard interface; `HashType` decides what sort of hash values are returned (canonical, regular, different `value_type`s (maybe you want `uint32_t` for some reason?), etc.). `HashShifter<T>` **derives** from `T`: it's a policy-based design model where `T` provides an optimized implementation, and it avoids anything beinv `virtual`. The most important methods exposed by the `HashShifter` are `shift_right(char out, char in)` and `shift_left(char in, char out)`, which update the current hash value with new symbols. Clearly, this implies they are stateful.\n",
+    "\n",
+    "Because `dBG` is a `HashShifter`, we can use the existing graph to demostrate its methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CanonicalModel fw=1376280362712374913 rc=16264769942947757911 sign=1>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# kmer is 'A' * K\n",
+    "graph.hash_base(kmer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CanonicalModel fw=18429189216377515994 rc=11251502874266433223 sign=0>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get rid of an A on the left, add a T on the right\n",
+    "graph.shift_right('A', 'T')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.hash('A' * (K - 1) + 'T') == graph.get_hash()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some notes: `get_hash(...)` gets the current hash of the shifter; `hash(...)` is non-volatile (does not affect the underlying state); and `hash_base(...)` primes the shifter with its initial value. Calling `shift_{left,right}` on an unititialized shifter will raise an exception. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The HashExtender\n",
+    "\n",
+    "Next up the chain is the `HashExtender`. The `HashExtender` once again uses a policy to offer optimized implementions, in this case, for getting potential neighboring hash values in a dBG based on its alphabet: ie, extending. The `HashExtender` keeps more state in order to enable repeated extensions after shifting. It uses a [circular (or ring) buffer](https://en.wikipedia.org/wiki/Circular_buffer) to store the symbols of the current $k$-mer, which we call the cursor. In the end, the `HashExtender` is itself a `HashShifter`, though it overrides a few methods to stay consistent. It provides `set_cursor(str)` and `get_cursor(str)` for setting the state, and `hash_base` now makes a call to `set_cursor(str)` under the hood to make sure the buffer gets loaded.\n",
+    "\n",
+    "Most importantly, it provides extension methods. Note that `dBG` is also a `HashExtender`, so we can use the existing graph to demo:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "kmer = 'TCACACCTCTGTGTTGTGCTACTTGCGGCGC'\n",
+    "graph.set_cursor(kmer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'TCACACCTCTGTGTTGTGCTACTTGCGGCGC'"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.get_cursor()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because we keep state, we can just call `shift_right(symbol)`, without providing the symbol to remove:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CanonicalModel fw=7170494598487408972 rc=16043475115312428656 sign=1>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.shift_right('A')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'CACACCTCTGTGTTGTGCTACTTGCGGCGCA'"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.get_cursor()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can ask for the extensions of the current cursor. If we ask for the left extensions, we should see the earlier hash value amongst them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<ShiftModel hash=<CanonicalModel fw=12345526596623405415 rc=11494181310317096217 sign=0> symbol=A direction=0>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=6756202371005322454 rc=1628793635298901189 sign=0> symbol=C direction=0>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=8758330460264747644 rc=5289963226481314134 sign=0> symbol=G direction=0>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0> symbol=T direction=0>]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.left_extensions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<ShiftModel hash=<CanonicalModel fw=2234471427066309240 rc=4231802296200205098 sign=1> symbol=A direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=2679775005173563244 rc=10806639864229157281 sign=1> symbol=C direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=8846023511076178687 rc=12804271227938578187 sign=1> symbol=G direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=17571437905152908067 rc=5127116808213764794 sign=0> symbol=T direction=1>]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.right_extensions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CanonicalModel fw=7170494598487408972 rc=16043475115312428656 sign=1>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.get_hash()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also take note that the underlying hash value is still the same as it was before we asked for extensions. The extension methods leave the shifter back in its originaly state.\n",
+    "\n",
+    "You might notice that this returned something called a `Shift`. The `Shift` is just a hash value with an attached symbol and direction. Just like the `Canonical`, it has a `value` property that retrieves the canonical hash value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2234471427066309240, 'A')"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "shift = graph.right_extensions()[0]\n",
+    "shift.value, shift.symbol"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The dBGWalker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just one last abstraction layer! The Final Form of the `HashShifter` is the `dBGWalker`. Once again, just as the `HashExtender` is a `HashShifter`, the `dBGWalker` is a `HashExtender`. The difference is that the `dBGWalker` can **not** be instantiated on its own: it can only be instantiated when by a `dBG` deriving from it! Obviously, if we wanna walk a dBG, we need a dBG to walk.\n",
+    "\n",
+    "The `dBGWalker` provides all the traversal-related methods to the `dBG`. For example, we can get the neighbors of the node ($k$-mer) pointed to by the current cursor.\n",
+    "\n",
+    "**NOTE**: Due to a temporary regression in `cppyy`, the return results of several methods that return `std::vector` cannot be transformed directly into lists, either implicitly or by calling `list(ret)`. So, I'm going to add a little utility function here for it. This should be fixed eventually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def to_list(vec): return [v for v in vec]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([], [], 'TCACACCTCTGTGTTGTGCTACTTGCGGCGC')"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.insert(graph.set_cursor(kmer))\n",
+    "to_list(graph.in_neighbors()), to_list(graph.out_neighbors()), kmer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Well that's sad. Let's give this guy some neighbors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The attribute `hash` on `Shift` provides the hash object, which we can insert directly\n",
+    "for node in graph.right_extensions()[0:2]:\n",
+    "    graph.insert(node.hash)\n",
+    "graph.insert(graph.left_extensions()[0].hash)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now our little node shouldn't be so lonely..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([(7847775928338814768, 'A')],\n",
+       " [(7170494598487408972, 'A'), (6462841522242458712, 'C')])"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[(node.value, node.symbol) for node in graph.in_neighbors()], [(node.value, node.symbol) for node in graph.out_neighbors()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Much better! =)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dBGWalker` uses lower-level primitives for its neighbor-finding and traversal. One such primitive is `filter_nodes`, which takes the result of an extension call and returns only the nodes that are actually in the `dBG`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(7847775928338814768, 'A')]"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from cppyy.gbl import std\n",
+    "[(node.value, node.symbol) for node in graph.filter_nodes(std.vector[graph.shift_left_type](graph.left_extensions()))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most users will not need to use such low level interfaces. So now, after that long digression, back to our original programming."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Walking the dBG\n",
+    "\n",
+    "Obviously, the more interesting case is actually traversing the dBG. The `dBGWalker` provides a rich interface for taking a stroll around the graph. To demo, let's first build up our graph..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<CanonicalModel fw=7847775928338814768 rc=11167344157054741611 sign=1>"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# first let's put our cursor on the far left of what we already inserted...\n",
+    "graph.set_cursor(kmer)\n",
+    "graph.shift_left('A')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([(84412478834819436, 'A')], [(8312430231874395202, 'C')])"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# no left neighbors, one right neighbor\n",
+    "[(node.value, node.symbol) for node in graph.in_neighbors()], [(node.value, node.symbol) for node in graph.out_neighbors()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "          AATCACACCTCTGTGTTGTGCTACTTGCGGC\n",
+      "         GAATCACACCTCTGTGTTGTGCTACTTGCGG\n",
+      "        GGAATCACACCTCTGTGTTGTGCTACTTGCG\n",
+      "       AGGAATCACACCTCTGTGTTGTGCTACTTGC\n",
+      "      GAGGAATCACACCTCTGTGTTGTGCTACTTG\n",
+      "     GGAGGAATCACACCTCTGTGTTGTGCTACTT\n",
+      "    AGGAGGAATCACACCTCTGTGTTGTGCTACT\n",
+      "   TAGGAGGAATCACACCTCTGTGTTGTGCTAC\n",
+      "  GTAGGAGGAATCACACCTCTGTGTTGTGCTA\n",
+      " GGTAGGAGGAATCACACCTCTGTGTTGTGCT\n"
+     ]
+    }
+   ],
+   "source": [
+    "seq = 'GGTAGGAGGA'\n",
+    "for i, base in enumerate(seq[::-1]):\n",
+    "    graph.insert(graph.shift_left(base))\n",
+    "    print(((len(seq) - i ) * ' ') + graph.get_cursor())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('GGTAGGAGGAATCACACCTCTGTGTTGTGCT',\n",
+       " <CanonicalModel fw=10388554386607035669 rc=1182107035245116275 sign=0>)"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "anchor = graph.get_cursor()\n",
+    "anchor, graph.get_hash()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Okay, now that we've added some $k$-mers, let's walk around. We've set the current position, which is on the far left of the path we inserted, as an \"anchor,\" so that we can go back to it.\n",
+    "\n",
+    "#### Steppin'\n",
+    "\n",
+    "Now, for some jargon. A sequence of connected nodes can be called a path, a walk, or a traversal. We're just going to call it a walk. We'll call one transition from node-to-node a step. The API conforms to this terminology:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "end_state, options = graph.step_right()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(7,\n",
+       " [<ShiftModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>])"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "end_state, [n for n in options]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`step_{left,right}` is somewhat self-explanatory: it steps right from the current position. The return values, however, require explanation. `end_state` is an enum of type `boink::TraversalState::State`, which is defined as follows:\n",
+    "\n",
+    "    namespace TraversalState {\n",
+    "        enum State {\n",
+    "            STOP_FWD,        // 0\n",
+    "            DECISION_FWD,    // 1\n",
+    "            DECISION_BKW,    // 2\n",
+    "            STOP_SEEN,       // 3\n",
+    "            STOP_MASKED,     // 4\n",
+    "            BAD_SEED,        // 5\n",
+    "            GRAPH_ERROR,     // 6\n",
+    "            STEP             // 7\n",
+    "        };\n",
+    "    }\n",
+    "    \n",
+    "The states describe how are traversal/walk/step ends. Unfortunately, the current C++ bindings don't convert these to strings, but it's On The List. For now, we can see that our end state was `7`, which corresponds to `STEP`. This quite simply means that we were able to take a step right, and did, because there was only one neighbor and one possible step. `options` is the list of where we could have gone -- but in order to `STEP`, this had to be exactly one! Had there been two or more, our end state would have `DECISION_FWD`. We'd have stayed where we started.\n",
+    "\n",
+    "Here is the complete state description:\n",
+    " * `STOP_FWD`: there are no neighbors in this direction.\n",
+    " * `DECISION_FWD`: there is more than one neighbor.\n",
+    " * `STOP_SEEN`: there is a single neighbor but it has been seen.\n",
+    " * `DECISION_BKW`: There is a single neighbor, but it is a decision in the other direction.\n",
+    " * `STOP_MASKED`: There is a single neighbor, but it is masked.\n",
+    " * `BAD_SEED`: The node you tried to start at does not exist.\n",
+    " * `GRAPH_ERROR`: The graph is structural unsound (basically a panic).\n",
+    " * `STEP`: None of the above: we can move\n",
+    "\n",
+    "Note that there are other states where we can have exactly one neighbor but not move: it could have been seen already, or it could have been a backwards decision node. A backwards d-node (`DECISION_BKW`) means that, were we to step right, our in-degree would be two or greater (and correspondingly for `step_left`).\n",
+    "\n",
+    "\n",
+    "If we check now, we'll see that we've moved, and we've got one in- and one out-neighbor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([(1182107035245116275, 'G')], [(7801055356572192737, 'C')])"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[(node.value, node.symbol) for node in graph.in_neighbors()], [(node.value, node.symbol) for node in graph.out_neighbors()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we reset back to the anchor and try again, we'll get a `STOP_SEEN`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3,\n",
+       " [<ShiftModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>],\n",
+       " <CanonicalModel fw=10388554386607035669 rc=1182107035245116275 sign=0>)"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.set_cursor(anchor)\n",
+    "end_state, options = graph.step_right()\n",
+    "end_state, to_list(options), graph.get_hash()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dBGWalker` maintains a set of already-seen nodes to prevent getting stuck in cycles, so we remain at anchor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[8224377023565475682]"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(graph.seen)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not to worry though, we can clear it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(7,\n",
+       " [<ShiftModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>],\n",
+       " <CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0>)"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.clear_seen()\n",
+    "end_state, options = graph.step_right()\n",
+    "end_state, to_list(options), graph.get_hash()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Walkin'\n",
+    "\n",
+    "Moving anywhere would be pretty hard if we had to manually think about stepping every time we did it, and the same with walking a dBG! For that, we have the `walk{left,right}` methods. These call `step_*` repeatedly until they reach a seen $k$-mer or create a partial unitig. We can either walk from our current position or given a seed to start at -- for now we'll just start at our current position."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "walk = graph.walk_right()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`walk*` returns a special `Walk` object. It has the following attributes:\n",
+    "* `start`: A `kmer_type` for the position we started at.\n",
+    "* `path`: A list of shifts holding the extensions for the path.\n",
+    "* `end_state`: The traversal state we ended on.\n",
+    "* `head()`: The hash value of start.\n",
+    "* `tail()`: The has value of the last extension (where we ended).\n",
+    "* `to_string()`: The string representation of the walk, resulting from combining the start $k$-mer with the extensions (specialized for direction).\n",
+    "* `glue(Walk)`: The string resulting from glueing two walks of the opposite direction together.\n",
+    "\n",
+    "In this case, we stopped on a forward decision node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(<KmerModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> kmer=GTAGGAGGAATCACACCTCTGTGTTGTGCTA>,\n",
+       " 1)"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "walk.start, walk.end_state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, <CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0>)"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.get_hash() == walk.tail(), walk.tail()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<ShiftModel hash=<CanonicalModel fw=14637547382867799967 rc=7801055356572192737 sign=0> symbol=C direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=13010390999111524039 rc=3221253690059650609 sign=0> symbol=T direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=12749353867514261335 rc=18060366745909523060 sign=1> symbol=T direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=10703243689465863068 rc=885851925541808064 sign=0> symbol=G direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=9490228497282697113 rc=6014014112993225648 sign=0> symbol=C direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=6306066054953700407 rc=12958152393930660101 sign=1> symbol=G direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=6508651095222951261 rc=12173448819754021496 sign=1> symbol=G direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=2162203961694194202 rc=84412478834819436 sign=0> symbol=C direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=7847775928338814768 rc=11167344157054741611 sign=1> symbol=G direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0> symbol=C direction=1>]"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "to_list(walk.path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'GTAGGAGGAATCACACCTCTGTGTTGTGCTACTTGCGGCGC'"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "walk.to_string()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You'll notice that `walk.tail()` and `graph.get_has()` correspond to `kmer` from way up before. We made `kmer` a decision node when we gave it two friends to its right:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<ShiftModel hash=<CanonicalModel fw=7170494598487408972 rc=16043475115312428656 sign=1> symbol=A direction=1>,\n",
+       " <ShiftModel hash=<CanonicalModel fw=6462841522242458712 rc=8207629909326200059 sign=1> symbol=C direction=1>]"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[n for n in graph.out_neighbors()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You might also recall that `anchor` had no in-neighbors. That means congratulations are in order -- we've just assembled a unitig!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/dBG Traversal Demo.ipynb
+++ b/examples/dBG Traversal Demo.ipynb
@@ -13,12 +13,22 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8.87 s, sys: 504 ms, total: 9.38 s\n",
+      "Wall time: 8.91 s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "# import boink libraries\n",
     "from boink import libboink\n",
     "from boink.dbg import dBG, Graph\n",
-    "from boink.hashing import CanRollingShifter\n",
+    "from boink.hashing import CanLemireShifter\n",
     "from boink.storage import SparseppSetStorage"
    ]
   },
@@ -31,7 +41,7 @@
     "First. some explanation as to these classes. We have, from `boink.dbg`:\n",
     "- `dBG`: This is the wrapped C++ dBG implementation. It is templated with a storage type and a hasher type; the storage type decides the underlying $k$-mer store, while the hashing type decides the hashing policy. Template class wrapped by `cppyy` are subscriptable, returning a complete class.\n",
     "- `Graph`: A thin wrapper function around `dBG`. Called with the storage and hashing types, it returns a funtion that takes $K$, a tuple of storage arguments, and a tuple of hashing arguments. When calling the `dBG` constructor directly, one must pass in an already-constructed storage and hasher. Note that the latter method has uses as well, as it allows multiple `dBG`'s to share the same underling storage.\n",
-    "- `CanRollingShifter`: This is a hashing policy. It wraps [Lemire's rolling hash implementation](https://github.com/lemire/rollinghashcpp) and returns canonical hashes. The return type is `CanonicalModel<uint64_t>`, which has the attributes `fw_hash` and `rc_hash` for each strand (relative to the given sequence), along with the property `value` which returns the canonical hash.\n",
+    "- `CanLemireShifter`: This is a hashing method. It wraps [Lemire's rolling hash implementation](https://github.com/lemire/rollinghashcpp) and returns canonical hashes. The return type is `Canonical<uint64_t>`, which has the attributes `fw_hash` and `rc_hash` for each strand (relative to the given sequence), along with the property `value` which returns the canonical hash.\n",
     "- `SparseppSetStorage`: A $k$-mer store for the `dBG` using the lightweight [sparsepp](https://github.com/greg7mdp/sparsepp) hash table. `sparsepp` is significantly faster than `std::map` or `std::set`. Given that it's a regular hash table, this is an exact storage backend.\n",
     "\n",
     "\n",
@@ -45,9 +55,9 @@
    "outputs": [],
    "source": [
     "K = 31\n",
-    "hasher = CanRollingShifter(K)\n",
+    "hasher = CanLemireShifter(K)\n",
     "storage = SparseppSetStorage.build()\n",
-    "graph = dBG[SparseppSetStorage, CanRollingShifter](storage, hasher)"
+    "graph = dBG[SparseppSetStorage, CanLemireShifter](storage, hasher)"
    ]
   },
   {
@@ -67,7 +77,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.dBG<boink::storage::SparseppSetStorage,boink::hashing::HashShifter<boink::hashing::RollingHashShifter<boink::hashing::CanonicalModel<unsigned long>,boink::DNA_SIMPLE> > > at 0x562e1cdc3370>"
+       "<class boink.boink.dBG<boink::storage::SparseppSetStorage,boink::hashing::HashShifter<boink::hashing::LemireShifterPolicy<boink::hashing::Canonical<unsigned long>,boink::DNA_SIMPLE> > > at 0x55dad4cb6820>"
       ]
      },
      "execution_count": 3,
@@ -266,7 +276,7 @@
     {
      "data": {
       "text/plain": [
-       "<CanonicalModel fw=1376280362712374913 rc=16264769942947757911 sign=1>"
+       "<Canonical fw=1376280362712374913 rc=16264769942947757911 sign=1>"
       ]
      },
      "execution_count": 10,
@@ -321,7 +331,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.hashing.CanonicalModel<unsigned long> at 0x562e21721660>"
+       "<class boink.boink.hashing.Canonical<unsigned long> at 0x55dad962f0a0>"
       ]
      },
      "execution_count": 12,
@@ -342,7 +352,7 @@
     {
      "data": {
       "text/plain": [
-       "<KmerModel hash=<CanonicalModel fw=1376280362712374913 rc=16264769942947757911 sign=1> kmer=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>"
+       "<Kmer hash=<Canonical fw=1376280362712374913 rc=16264769942947757911 sign=1> kmer=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>"
       ]
      },
      "execution_count": 13,
@@ -364,7 +374,7 @@
     {
      "data": {
       "text/plain": [
-       "<class boink.boink.hashing.HashShifter<boink::hashing::RollingHashShifter<boink::hashing::CanonicalModel<unsigned long>,boink::DNA_SIMPLE> > at 0x562e1c653b20>"
+       "<class boink.boink.hashing.HashShifter<boink::hashing::LemireShifterPolicy<boink::hashing::Canonical<unsigned long>,boink::DNA_SIMPLE> > at 0x55dad44ff7a0>"
       ]
      },
      "execution_count": 14,
@@ -381,7 +391,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Additionally, there's the alphabet. `CanRollingShifter` is just a typedef that omits a template parameter that decides the alphabet of the dBG. It's statically accessible on the `dBG` (and the `HashShifter`) through the alphabet attribute, and has several useful statically defined methods."
+    "Additionally, there's the alphabet. `CanLemireShifter` is just a typedef that omits a template parameter that decides the alphabet of the dBG. It's statically accessible on the `dBG` (and the `HashShifter`) through the alphabet attribute, and has several useful statically defined methods."
    ]
   },
   {
@@ -393,7 +403,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class boink.boink.DNA_SIMPLE at 0x562e21ae2c00>, ACGT, TGCA\n"
+      "<class boink.boink.DNA_SIMPLE at 0x55dad509caa0>, ACGT, TGCA\n"
      ]
     }
    ],
@@ -462,7 +472,7 @@
     {
      "data": {
       "text/plain": [
-       "<CanonicalModel fw=1376280362712374913 rc=16264769942947757911 sign=1>"
+       "<Canonical fw=1376280362712374913 rc=16264769942947757911 sign=1>"
       ]
      },
      "execution_count": 18,
@@ -483,7 +493,7 @@
     {
      "data": {
       "text/plain": [
-       "<CanonicalModel fw=18429189216377515994 rc=11251502874266433223 sign=0>"
+       "<Canonical fw=18429189216377515994 rc=11251502874266433223 sign=0>"
       ]
      },
      "execution_count": 19,
@@ -542,7 +552,7 @@
     {
      "data": {
       "text/plain": [
-       "<CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0>"
+       "<Canonical fw=15476993202998089975 rc=8312430231874395202 sign=0>"
       ]
      },
      "execution_count": 21,
@@ -590,7 +600,7 @@
     {
      "data": {
       "text/plain": [
-       "<CanonicalModel fw=7170494598487408972 rc=16043475115312428656 sign=1>"
+       "<Canonical fw=7170494598487408972 rc=16043475115312428656 sign=1>"
       ]
      },
      "execution_count": 23,
@@ -637,10 +647,10 @@
     {
      "data": {
       "text/plain": [
-       "[<ShiftModel hash=<CanonicalModel fw=12345526596623405415 rc=11494181310317096217 sign=0> symbol=A direction=0>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=6756202371005322454 rc=1628793635298901189 sign=0> symbol=C direction=0>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=8758330460264747644 rc=5289963226481314134 sign=0> symbol=G direction=0>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0> symbol=T direction=0>]"
+       "[<Shift hash=<Canonical fw=12345526596623405415 rc=11494181310317096217 sign=0> symbol=A direction=0>,\n",
+       " <Shift hash=<Canonical fw=6756202371005322454 rc=1628793635298901189 sign=0> symbol=C direction=0>,\n",
+       " <Shift hash=<Canonical fw=8758330460264747644 rc=5289963226481314134 sign=0> symbol=G direction=0>,\n",
+       " <Shift hash=<Canonical fw=15476993202998089975 rc=8312430231874395202 sign=0> symbol=T direction=0>]"
       ]
      },
      "execution_count": 25,
@@ -660,10 +670,10 @@
     {
      "data": {
       "text/plain": [
-       "[<ShiftModel hash=<CanonicalModel fw=2234471427066309240 rc=4231802296200205098 sign=1> symbol=A direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=2679775005173563244 rc=10806639864229157281 sign=1> symbol=C direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=8846023511076178687 rc=12804271227938578187 sign=1> symbol=G direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=17571437905152908067 rc=5127116808213764794 sign=0> symbol=T direction=1>]"
+       "[<Shift hash=<Canonical fw=2234471427066309240 rc=4231802296200205098 sign=1> symbol=A direction=1>,\n",
+       " <Shift hash=<Canonical fw=2679775005173563244 rc=10806639864229157281 sign=1> symbol=C direction=1>,\n",
+       " <Shift hash=<Canonical fw=8846023511076178687 rc=12804271227938578187 sign=1> symbol=G direction=1>,\n",
+       " <Shift hash=<Canonical fw=17571437905152908067 rc=5127116808213764794 sign=0> symbol=T direction=1>]"
       ]
      },
      "execution_count": 26,
@@ -683,7 +693,7 @@
     {
      "data": {
       "text/plain": [
-       "<CanonicalModel fw=7170494598487408972 rc=16043475115312428656 sign=1>"
+       "<Canonical fw=7170494598487408972 rc=16043475115312428656 sign=1>"
       ]
      },
      "execution_count": 27,
@@ -890,7 +900,7 @@
     {
      "data": {
       "text/plain": [
-       "<CanonicalModel fw=7847775928338814768 rc=11167344157054741611 sign=1>"
+       "<Canonical fw=7847775928338814768 rc=11167344157054741611 sign=1>"
       ]
      },
      "execution_count": 34,
@@ -963,7 +973,7 @@
      "data": {
       "text/plain": [
        "('GGTAGGAGGAATCACACCTCTGTGTTGTGCT',\n",
-       " <CanonicalModel fw=10388554386607035669 rc=1182107035245116275 sign=0>)"
+       " <Canonical fw=10388554386607035669 rc=1182107035245116275 sign=0>)"
       ]
      },
      "execution_count": 37,
@@ -1005,7 +1015,7 @@
      "data": {
       "text/plain": [
        "(7,\n",
-       " [<ShiftModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>])"
+       " [<Shift hash=<Canonical fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>])"
       ]
      },
      "execution_count": 39,
@@ -1090,8 +1100,8 @@
      "data": {
       "text/plain": [
        "(3,\n",
-       " [<ShiftModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>],\n",
-       " <CanonicalModel fw=10388554386607035669 rc=1182107035245116275 sign=0>)"
+       " [<Shift hash=<Canonical fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>],\n",
+       " <Canonical fw=10388554386607035669 rc=1182107035245116275 sign=0>)"
       ]
      },
      "execution_count": 41,
@@ -1148,8 +1158,8 @@
      "data": {
       "text/plain": [
        "(7,\n",
-       " [<ShiftModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>],\n",
-       " <CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0>)"
+       " [<Shift hash=<Canonical fw=12736750171723927455 rc=8224377023565475682 sign=0> symbol=A direction=1>],\n",
+       " <Canonical fw=12736750171723927455 rc=8224377023565475682 sign=0>)"
       ]
      },
      "execution_count": 43,
@@ -1205,7 +1215,7 @@
     {
      "data": {
       "text/plain": [
-       "(<KmerModel hash=<CanonicalModel fw=12736750171723927455 rc=8224377023565475682 sign=0> kmer=GTAGGAGGAATCACACCTCTGTGTTGTGCTA>,\n",
+       "(<Kmer hash=<Canonical fw=12736750171723927455 rc=8224377023565475682 sign=0> kmer=GTAGGAGGAATCACACCTCTGTGTTGTGCTA>,\n",
        " 1)"
       ]
      },
@@ -1226,7 +1236,7 @@
     {
      "data": {
       "text/plain": [
-       "(True, <CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0>)"
+       "(True, <Canonical fw=15476993202998089975 rc=8312430231874395202 sign=0>)"
       ]
      },
      "execution_count": 46,
@@ -1246,16 +1256,16 @@
     {
      "data": {
       "text/plain": [
-       "[<ShiftModel hash=<CanonicalModel fw=14637547382867799967 rc=7801055356572192737 sign=0> symbol=C direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=13010390999111524039 rc=3221253690059650609 sign=0> symbol=T direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=12749353867514261335 rc=18060366745909523060 sign=1> symbol=T direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=10703243689465863068 rc=885851925541808064 sign=0> symbol=G direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=9490228497282697113 rc=6014014112993225648 sign=0> symbol=C direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=6306066054953700407 rc=12958152393930660101 sign=1> symbol=G direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=6508651095222951261 rc=12173448819754021496 sign=1> symbol=G direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=2162203961694194202 rc=84412478834819436 sign=0> symbol=C direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=7847775928338814768 rc=11167344157054741611 sign=1> symbol=G direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=15476993202998089975 rc=8312430231874395202 sign=0> symbol=C direction=1>]"
+       "[<Shift hash=<Canonical fw=14637547382867799967 rc=7801055356572192737 sign=0> symbol=C direction=1>,\n",
+       " <Shift hash=<Canonical fw=13010390999111524039 rc=3221253690059650609 sign=0> symbol=T direction=1>,\n",
+       " <Shift hash=<Canonical fw=12749353867514261335 rc=18060366745909523060 sign=1> symbol=T direction=1>,\n",
+       " <Shift hash=<Canonical fw=10703243689465863068 rc=885851925541808064 sign=0> symbol=G direction=1>,\n",
+       " <Shift hash=<Canonical fw=9490228497282697113 rc=6014014112993225648 sign=0> symbol=C direction=1>,\n",
+       " <Shift hash=<Canonical fw=6306066054953700407 rc=12958152393930660101 sign=1> symbol=G direction=1>,\n",
+       " <Shift hash=<Canonical fw=6508651095222951261 rc=12173448819754021496 sign=1> symbol=G direction=1>,\n",
+       " <Shift hash=<Canonical fw=2162203961694194202 rc=84412478834819436 sign=0> symbol=C direction=1>,\n",
+       " <Shift hash=<Canonical fw=7847775928338814768 rc=11167344157054741611 sign=1> symbol=G direction=1>,\n",
+       " <Shift hash=<Canonical fw=15476993202998089975 rc=8312430231874395202 sign=0> symbol=C direction=1>]"
       ]
      },
      "execution_count": 47,
@@ -1302,8 +1312,8 @@
     {
      "data": {
       "text/plain": [
-       "[<ShiftModel hash=<CanonicalModel fw=7170494598487408972 rc=16043475115312428656 sign=1> symbol=A direction=1>,\n",
-       " <ShiftModel hash=<CanonicalModel fw=6462841522242458712 rc=8207629909326200059 sign=1> symbol=C direction=1>]"
+       "[<Shift hash=<Canonical fw=7170494598487408972 rc=16043475115312428656 sign=1> symbol=A direction=1>,\n",
+       " <Shift hash=<Canonical fw=6462841522242458712 rc=8207629909326200059 sign=1> symbol=C direction=1>]"
       ]
      },
      "execution_count": 49,
@@ -1319,7 +1329,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You might also recall that `anchor` had no in-neighbors. That means congratulations are in order -- we've just assembled a unitig!"
+    "You might also recall that `anchor` had no in-neighbors. That means congratulations are in order -- we've just assembled a unitig!\n",
+    "\n",
+    "#### Traversin'\n",
+    "\n",
+    "So now that we've walked a unitig, it's time to traverse to the rest of its neighbors. "
    ]
   }
  ],

--- a/include/boink/cdbg/cdbg.hh
+++ b/include/boink/cdbg/cdbg.hh
@@ -1683,20 +1683,20 @@ public:
 
 }
 
-extern template class cdbg::cDBG<dBG<storage::BitStorage, hashing::FwdRollingShifter>>;
-extern template class cdbg::cDBG<dBG<storage::BitStorage, hashing::CanRollingShifter>>;
+extern template class cdbg::cDBG<dBG<storage::BitStorage, hashing::FwdLemireShifter>>;
+extern template class cdbg::cDBG<dBG<storage::BitStorage, hashing::CanLemireShifter>>;
 
-extern template class cdbg::cDBG<dBG<storage::SparseppSetStorage, hashing::FwdRollingShifter>>;
-extern template class cdbg::cDBG<dBG<storage::SparseppSetStorage, hashing::CanRollingShifter>>;
+extern template class cdbg::cDBG<dBG<storage::SparseppSetStorage, hashing::FwdLemireShifter>>;
+extern template class cdbg::cDBG<dBG<storage::SparseppSetStorage, hashing::CanLemireShifter>>;
 
-extern template class cdbg::cDBG<dBG<storage::ByteStorage, hashing::FwdRollingShifter>>;
-extern template class cdbg::cDBG<dBG<storage::ByteStorage, hashing::CanRollingShifter>>;
+extern template class cdbg::cDBG<dBG<storage::ByteStorage, hashing::FwdLemireShifter>>;
+extern template class cdbg::cDBG<dBG<storage::ByteStorage, hashing::CanLemireShifter>>;
 
-extern template class cdbg::cDBG<dBG<storage::NibbleStorage, hashing::FwdRollingShifter>>;
-extern template class cdbg::cDBG<dBG<storage::NibbleStorage, hashing::CanRollingShifter>>;
+extern template class cdbg::cDBG<dBG<storage::NibbleStorage, hashing::FwdLemireShifter>>;
+extern template class cdbg::cDBG<dBG<storage::NibbleStorage, hashing::CanLemireShifter>>;
 
-extern template class cdbg::cDBG<dBG<storage::QFStorage, hashing::FwdRollingShifter>>;
-extern template class cdbg::cDBG<dBG<storage::QFStorage, hashing::CanRollingShifter>>;
+extern template class cdbg::cDBG<dBG<storage::QFStorage, hashing::FwdLemireShifter>>;
+extern template class cdbg::cDBG<dBG<storage::QFStorage, hashing::CanLemireShifter>>;
 
 }
 

--- a/include/boink/cdbg/compactor.hh
+++ b/include/boink/cdbg/compactor.hh
@@ -61,7 +61,7 @@ struct StreamingCompactor<GraphType<StorageType, ShifterType>> {
     typedef typename shifter_type::kmer_type    kmer_type;
 
     template<bool Dir>
-        using shift_type = hashing::ShiftModel<hash_type, Dir>;
+        using shift_type = hashing::Shift<hash_type, Dir>;
 
     typedef dBGWalker<graph_type>               walker_type;
     template<bool Dir>

--- a/include/boink/cdbg/compactor.hh
+++ b/include/boink/cdbg/compactor.hh
@@ -1358,13 +1358,13 @@ struct StreamingCompactor<GraphType<StorageType, ShifterType>> {
 }
 }
 
-extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::SparseppSetStorage, boink::hashing::FwdRollingShifter>>;
-extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::BitStorage, boink::hashing::FwdRollingShifter>>;
-extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::ByteStorage, boink::hashing::FwdRollingShifter>>;
-extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::NibbleStorage, boink::hashing::FwdRollingShifter>>;
-extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::QFStorage, boink::hashing::FwdRollingShifter>>;
+extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::SparseppSetStorage, boink::hashing::FwdLemireShifter>>;
+extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::BitStorage, boink::hashing::FwdLemireShifter>>;
+extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::ByteStorage, boink::hashing::FwdLemireShifter>>;
+extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::NibbleStorage, boink::hashing::FwdLemireShifter>>;
+extern template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::QFStorage, boink::hashing::FwdLemireShifter>>;
 
-extern template class std::deque<boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::SparseppSetStorage, boink::hashing::FwdRollingShifter>>>;
+extern template class std::deque<boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::SparseppSetStorage, boink::hashing::FwdLemireShifter>>>;
 
 
 #undef pdebug

--- a/include/boink/cdbg/compactor.hh
+++ b/include/boink/cdbg/compactor.hh
@@ -28,7 +28,6 @@
 namespace boink {
 namespace cdbg {
 
-# define DEBUG_CPTR
 # ifdef DEBUG_CPTR
 #   define pdebug(x) do { std::cerr << std::endl << "@ " << __FILE__ <<\
                           ":" << __FUNCTION__ << ":" <<\

--- a/include/boink/dbg.hh
+++ b/include/boink/dbg.hh
@@ -405,78 +405,78 @@ public:
 };
 
 
-extern template class dBG<storage::BitStorage, hashing::FwdRollingShifter>;
-extern template class dBG<storage::BitStorage, hashing::CanRollingShifter>;
+extern template class dBG<storage::BitStorage, hashing::FwdLemireShifter>;
+extern template class dBG<storage::BitStorage, hashing::CanLemireShifter>;
 extern template class dBG<storage::BitStorage, hashing::FwdUnikmerShifter>;
 extern template class dBG<storage::BitStorage, hashing::CanUnikmerShifter>;
 
-extern template class dBG<storage::SparseppSetStorage, hashing::FwdRollingShifter>;
-extern template class dBG<storage::SparseppSetStorage, hashing::CanRollingShifter>;
+extern template class dBG<storage::SparseppSetStorage, hashing::FwdLemireShifter>;
+extern template class dBG<storage::SparseppSetStorage, hashing::CanLemireShifter>;
 extern template class dBG<storage::SparseppSetStorage, hashing::FwdUnikmerShifter>;
 extern template class dBG<storage::SparseppSetStorage, hashing::CanUnikmerShifter>;
 
-extern template class dBG<storage::ByteStorage, hashing::FwdRollingShifter>;
-extern template class dBG<storage::ByteStorage, hashing::CanRollingShifter>;
+extern template class dBG<storage::ByteStorage, hashing::FwdLemireShifter>;
+extern template class dBG<storage::ByteStorage, hashing::CanLemireShifter>;
 extern template class dBG<storage::ByteStorage, hashing::FwdUnikmerShifter>;
 extern template class dBG<storage::ByteStorage, hashing::CanUnikmerShifter>;
 
-extern template class dBG<storage::NibbleStorage, hashing::FwdRollingShifter>;
-extern template class dBG<storage::NibbleStorage, hashing::CanRollingShifter>;
+extern template class dBG<storage::NibbleStorage, hashing::FwdLemireShifter>;
+extern template class dBG<storage::NibbleStorage, hashing::CanLemireShifter>;
 extern template class dBG<storage::NibbleStorage, hashing::FwdUnikmerShifter>;
 extern template class dBG<storage::NibbleStorage, hashing::CanUnikmerShifter>;
 
-extern template class dBG<storage::QFStorage, hashing::FwdRollingShifter>;
-extern template class dBG<storage::QFStorage, hashing::CanRollingShifter>;
+extern template class dBG<storage::QFStorage, hashing::FwdLemireShifter>;
+extern template class dBG<storage::QFStorage, hashing::CanLemireShifter>;
 extern template class dBG<storage::QFStorage, hashing::FwdUnikmerShifter>;
 extern template class dBG<storage::QFStorage, hashing::CanUnikmerShifter>;
 
-extern template class dBGWalker<dBG<storage::BitStorage, hashing::FwdRollingShifter>>;
-extern template class dBGWalker<dBG<storage::BitStorage, hashing::CanRollingShifter>>;
+extern template class dBGWalker<dBG<storage::BitStorage, hashing::FwdLemireShifter>>;
+extern template class dBGWalker<dBG<storage::BitStorage, hashing::CanLemireShifter>>;
 extern template class dBGWalker<dBG<storage::BitStorage, hashing::FwdUnikmerShifter>>;
 extern template class dBGWalker<dBG<storage::BitStorage, hashing::CanUnikmerShifter>>;
 
-extern template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::FwdRollingShifter>>;
-extern template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::CanRollingShifter>>;
+extern template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::FwdLemireShifter>>;
+extern template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::CanLemireShifter>>;
 extern template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::FwdUnikmerShifter>>;
 extern template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::CanUnikmerShifter>>;
 
-extern template class dBGWalker<dBG<storage::ByteStorage, hashing::FwdRollingShifter>>;
-extern template class dBGWalker<dBG<storage::ByteStorage, hashing::CanRollingShifter>>;
+extern template class dBGWalker<dBG<storage::ByteStorage, hashing::FwdLemireShifter>>;
+extern template class dBGWalker<dBG<storage::ByteStorage, hashing::CanLemireShifter>>;
 extern template class dBGWalker<dBG<storage::ByteStorage, hashing::FwdUnikmerShifter>>;
 extern template class dBGWalker<dBG<storage::ByteStorage, hashing::CanUnikmerShifter>>;
 
-extern template class dBGWalker<dBG<storage::NibbleStorage, hashing::FwdRollingShifter>>;
-extern template class dBGWalker<dBG<storage::NibbleStorage, hashing::CanRollingShifter>>;
+extern template class dBGWalker<dBG<storage::NibbleStorage, hashing::FwdLemireShifter>>;
+extern template class dBGWalker<dBG<storage::NibbleStorage, hashing::CanLemireShifter>>;
 extern template class dBGWalker<dBG<storage::NibbleStorage, hashing::FwdUnikmerShifter>>;
 extern template class dBGWalker<dBG<storage::NibbleStorage, hashing::CanUnikmerShifter>>;
 
-extern template class dBGWalker<dBG<storage::QFStorage, hashing::FwdRollingShifter>>;
-extern template class dBGWalker<dBG<storage::QFStorage, hashing::CanRollingShifter>>;
+extern template class dBGWalker<dBG<storage::QFStorage, hashing::FwdLemireShifter>>;
+extern template class dBGWalker<dBG<storage::QFStorage, hashing::CanLemireShifter>>;
 extern template class dBGWalker<dBG<storage::QFStorage, hashing::FwdUnikmerShifter>>;
 extern template class dBGWalker<dBG<storage::QFStorage, hashing::CanUnikmerShifter>>;
 
-extern template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::FwdRollingShifter>>;
-extern template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::CanRollingShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::FwdLemireShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::CanLemireShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::FwdUnikmerShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::CanUnikmerShifter>>;
 
-extern template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::FwdRollingShifter>>;
-extern template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::CanRollingShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::FwdLemireShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::CanLemireShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::FwdUnikmerShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::CanUnikmerShifter>>;
 
-extern template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::FwdRollingShifter>>;
-extern template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::CanRollingShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::FwdLemireShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::CanLemireShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::FwdUnikmerShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::CanUnikmerShifter>>;
 
-extern template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::FwdRollingShifter>>;
-extern template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::CanRollingShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::FwdLemireShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::CanLemireShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::FwdUnikmerShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::CanUnikmerShifter>>;
 
-extern template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::FwdRollingShifter>>;
-extern template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::CanRollingShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::FwdLemireShifter>>;
+extern template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::CanLemireShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::FwdUnikmerShifter>>;
 extern template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::CanUnikmerShifter>>;
 

--- a/include/boink/dbg.hh
+++ b/include/boink/dbg.hh
@@ -47,7 +47,7 @@ public:
     typedef typename walker_type::kmer_type          kmer_type;
 
     template<bool Dir>
-        using shift_type = hashing::ShiftModel<hash_type, Dir>;
+        using shift_type = hashing::Shift<hash_type, Dir>;
 
     typedef std::pair<std::vector<shift_type<hashing::DIR_LEFT>>,
                       std::vector<shift_type<hashing::DIR_RIGHT>>> shift_pair_type;

--- a/include/boink/hashing/canonical.hh
+++ b/include/boink/hashing/canonical.hh
@@ -28,23 +28,23 @@ inline constexpr bool DIR_RIGHT = true;
  * @tparam ValueType Underlying storage type.
  */
 template<class ValueType = uint64_t>
-struct HashModel {
+struct Hash {
     
     typedef ValueType value_type;
 
     value_type hash;
 
-    HashModel(const value_type hash)
+    Hash(const value_type hash)
         : hash(hash)
     {
     }
 
-    HashModel()
+    Hash()
         : hash(std::numeric_limits<value_type>::max())
     {
     }
 
-    HashModel(const HashModel& other)
+    Hash(const Hash& other)
         : hash(other.hash)
     {
     }
@@ -58,17 +58,17 @@ struct HashModel {
     }
 
     __attribute__((visibility("default")))
-    friend bool operator>(const HashModel& lhs, const HashModel& rhs) {
+    friend bool operator>(const Hash& lhs, const Hash& rhs) {
         return lhs.value() > rhs.value();
     }
 
     __attribute__((visibility("default")))
-    friend bool operator<(const HashModel& lhs, const HashModel& rhs) {
+    friend bool operator<(const Hash& lhs, const Hash& rhs) {
         return lhs.value() < rhs.value();
     }
 
     __attribute__((visibility("default")))
-    friend bool operator==(const HashModel& lhs, const HashModel& rhs) {
+    friend bool operator==(const Hash& lhs, const Hash& rhs) {
         return lhs.value() == rhs.value();
     }
 };
@@ -76,8 +76,8 @@ struct HashModel {
 template<class ValueType>
 __attribute__((visibility("default")))
 inline std::ostream&
-operator<<(std::ostream& os, const HashModel<ValueType>& _this) {
-    os << "<HashModel h=" << _this.value()
+operator<<(std::ostream& os, const Hash<ValueType>& _this) {
+    os << "<Hash h=" << _this.value()
        << ">";
     return os;
 }
@@ -86,31 +86,31 @@ operator<<(std::ostream& os, const HashModel<ValueType>& _this) {
 /**
  * @Synopsis  Model for a canonical k-mer. Stores two value_type
  *            as fw and rc hashes; value() provides the canonical
- *            hash. Matches HashModel interface.
+ *            hash. Matches Hash interface.
  *
  * @tparam ValueType
  */
-template<class ValueType>
-struct CanonicalModel {
+template<class ValueType = uint64_t>
+struct Canonical {
 
     typedef ValueType value_type;
 
     value_type fw_hash, rc_hash;
 
-    CanonicalModel()
+    Canonical()
         : fw_hash(std::numeric_limits<value_type>::max()),
           rc_hash(std::numeric_limits<value_type>::max())
     {
     }
 
-    CanonicalModel(const value_type fw,
+    Canonical(const value_type fw,
                    const value_type rc)
         : fw_hash(fw),
           rc_hash(rc)
     {
     }
 
-    CanonicalModel(const CanonicalModel& other)
+    Canonical(const Canonical& other)
         : fw_hash(other.fw_hash),
           rc_hash(other.rc_hash)
     {
@@ -129,17 +129,17 @@ struct CanonicalModel {
     }
 
     __attribute__((visibility("default")))
-    friend bool operator>(const CanonicalModel& lhs, const CanonicalModel& rhs) {
+    friend bool operator>(const Canonical& lhs, const Canonical& rhs) {
         return lhs.value() > rhs.value();
     }
 
     __attribute__((visibility("default")))
-    friend bool operator<(const CanonicalModel& lhs, const CanonicalModel& rhs) {
+    friend bool operator<(const Canonical& lhs, const Canonical& rhs) {
         return lhs.value() < rhs.value();
     }
 
     __attribute__((visibility("default")))
-    friend bool operator==(const CanonicalModel& lhs, const CanonicalModel& rhs) {
+    friend bool operator==(const Canonical& lhs, const Canonical& rhs) {
         return lhs.value() == rhs.value();
     }
 
@@ -147,8 +147,8 @@ struct CanonicalModel {
 
 template<class ValueType> __attribute__((visibility("default")))
 inline std::ostream&
-operator<<(std::ostream& os, const CanonicalModel<ValueType>& _this) {
-    os << "<CanonicalModel"
+operator<<(std::ostream& os, const Canonical<ValueType>& _this) {
+    os << "<Canonical"
        << " fw=" << _this.fw_hash
        << " rc=" << _this.rc_hash
        << " sign=" << _this.sign()
@@ -159,9 +159,9 @@ operator<<(std::ostream& os, const CanonicalModel<ValueType>& _this) {
 
 /**
  * @Synopsis  Helper struct so we can write, for example, 
- *                WmerModel<HashModel<uint64_t>, Unikmer>
+ *                Wmer<Hash<uint64_t>, Unikmer>
  *            instead of
- *                WmerModel<HashModel, uint64_t, Unikmer>
+ *                Wmer<Hash, uint64_t, Unikmer>
  *            which makes later composition more general and
  *       safer.
  *
@@ -169,16 +169,16 @@ operator<<(std::ostream& os, const CanonicalModel<ValueType>& _this) {
  * @tparam MinimizerType
  */
 template<class T, class MinimizerType>
-struct WmerModel;
+struct Wmer;
 
 
 /**
- * @Synopsis  A HashModel with an associated minimizer.
+ * @Synopsis  A Hash with an associated minimizer.
  *
  */
 template<template<class> class HashType, class ValueType,
          class MinimizerType>
-struct WmerModel<HashType<ValueType>, MinimizerType> {
+struct Wmer<HashType<ValueType>, MinimizerType> {
    
     typedef HashType<ValueType> hash_type;
     typedef ValueType           value_type;
@@ -187,20 +187,20 @@ struct WmerModel<HashType<ValueType>, MinimizerType> {
     hash_type     hash;
     minimizer_type minimizer;
 
-    WmerModel(const hash_type&     hash,
+    Wmer(const hash_type&     hash,
               const minimizer_type& minimizer)
         : hash(hash),
           minimizer(minimizer)
     {
     }
 
-    WmerModel()
+    Wmer()
         : hash(),
           minimizer()
     {
     }
 
-    WmerModel(const WmerModel& other)
+    Wmer(const Wmer& other)
         : hash(other.hash),
           minimizer(other.minimizer)
     {
@@ -219,17 +219,17 @@ struct WmerModel<HashType<ValueType>, MinimizerType> {
     }
 
     __attribute__((visibility("default")))
-    friend bool operator>(const WmerModel& lhs, const WmerModel& rhs) {
+    friend bool operator>(const Wmer& lhs, const Wmer& rhs) {
         return lhs.hash > rhs.hash;
     }
 
     __attribute__((visibility("default")))
-    friend bool operator<(const WmerModel& lhs, const WmerModel& rhs) {
+    friend bool operator<(const Wmer& lhs, const Wmer& rhs) {
         return lhs.hash < rhs.hash;
     }
 
     __attribute__((visibility("default")))
-    friend bool operator==(const WmerModel& lhs, const WmerModel& rhs) {
+    friend bool operator==(const Wmer& lhs, const Wmer& rhs) {
         return lhs.hash == rhs.hash;
     }
 };
@@ -240,8 +240,8 @@ template<template<class> class HashType, class ValueType,
 __attribute__((visibility("default")))
 inline std::ostream&
 operator<<(std::ostream& os,
-           const WmerModel<HashType<ValueType>, MinimizerType>& wmer) {
-    os << "<WmerModel"
+           const Wmer<HashType<ValueType>, MinimizerType>& wmer) {
+    os << "<Wmer"
        << " hash=" << wmer.hash
        << " minimizer=" << wmer.minimizer
        << ">";
@@ -250,21 +250,21 @@ operator<<(std::ostream& os,
 
 
 template<typename T>
-struct KmerModel;
+struct Kmer;
 
 /**
  * @Synopsis  Models a Kmer: a Hash and its string repr. The hash_type
- *            must comform to the HashModel template interface.
+ *            must comform to the Hash template interface.
  *
- *            NOTE: The variadic Extras parameter is need so that KmerModel
- *            can accept a WmerModel as its HashType (or for that matter,
- *            anything that comforms to HashModel but takes extra
+ *            NOTE: The variadic Extras parameter is need so that Kmer
+ *            can accept a Wmer as its HashType (or for that matter,
+ *            anything that comforms to Hash but takes extra
  *            template parameters). Naturally, Extras can also just
- *            be empty, in which case it matches regular HashModel<uint64_t>
+ *            be empty, in which case it matches regular Hash<uint64_t>
  *            etc.
  */
 template<template<class, class...> class HashType, class ValueType, class...Extras>
-struct KmerModel<HashType<ValueType, Extras...>> {
+struct Kmer<HashType<ValueType, Extras...>> {
 
     typedef HashType<ValueType, Extras...> hash_type;
     typedef typename hash_type::value_type value_type;
@@ -272,20 +272,20 @@ struct KmerModel<HashType<ValueType, Extras...>> {
     hash_type hash;
     std::string kmer;
 
-    KmerModel(const hash_type& hash,
+    Kmer(const hash_type& hash,
               const std::string& kmer)
         : hash(hash),
           kmer(kmer)
     {
     }
 
-	KmerModel()
+	Kmer()
         : hash(),
           kmer(0, ' ')
     {
     }
 
-    KmerModel(const KmerModel& other)
+    Kmer(const Kmer& other)
         : hash(other.hash),
           kmer(other.kmer)
     {
@@ -304,17 +304,17 @@ struct KmerModel<HashType<ValueType, Extras...>> {
     }
 
     __attribute__((visibility("default")))
-    friend bool operator>(const KmerModel& lhs, const KmerModel& rhs) {
+    friend bool operator>(const Kmer& lhs, const Kmer& rhs) {
         return lhs.hash > rhs.hash;
     }
 
     __attribute__((visibility("default")))
-    friend bool operator<(const KmerModel& lhs, const KmerModel& rhs) {
+    friend bool operator<(const Kmer& lhs, const Kmer& rhs) {
         return lhs.hash < rhs.hash;
     }
 
     __attribute__((visibility("default")))
-    friend bool operator==(const KmerModel& lhs, const KmerModel& rhs) {
+    friend bool operator==(const Kmer& lhs, const Kmer& rhs) {
         return lhs.hash == rhs.hash;
     }
 };
@@ -324,8 +324,8 @@ template<template<class, class...> class HashType, class ValueType,
          class...Extras>
 __attribute__((visibility("default")))
 inline std::ostream&
-operator<<(std::ostream& os, const KmerModel<HashType<ValueType, Extras...>>& kmer) {
-    os << "<KmerModel"
+operator<<(std::ostream& os, const Kmer<HashType<ValueType, Extras...>>& kmer) {
+    os << "<Kmer"
        << " hash=" << kmer.hash
        << " kmer=" << kmer.kmer
        << ">";
@@ -336,9 +336,9 @@ operator<<(std::ostream& os, const KmerModel<HashType<ValueType, Extras...>>& km
 
 /**
  * @Synopsis  helper struct so we can write, for example, 
- *                ShiftModel<HashModel<uint64_t>, DIR_LEFT>
+ *                Shift<Hash<uint64_t>, DIR_LEFT>
  *            instead of
- *                ShiftModel<HashModel, uint64_t, DIR_LEFT>
+ *                Shift<Hash, uint64_t, DIR_LEFT>
  *            which makes later composition more general and
  *            safer. See specialization below.
  *
@@ -346,16 +346,16 @@ operator<<(std::ostream& os, const KmerModel<HashType<ValueType, Extras...>>& km
  * @tparam Direction 
  */
 template <class T, bool Direction>
-struct ShiftModel;
+struct Shift;
 
 /**
- * @Synopsis  Models a directional shift; conforms to HashModel
+ * @Synopsis  Models a directional shift; conforms to Hash
  *            and provides the direction and extension symbol.
  *
  */
 template <template<class, class...> class HashType, class ValueType, class... Extras,
           bool Direction>
-struct ShiftModel<HashType<ValueType, Extras...>, Direction> {
+struct Shift<HashType<ValueType, Extras...>, Direction> {
     
     typedef HashType<ValueType, Extras...> hash_type;
     typedef typename hash_type::value_type value_type;
@@ -364,21 +364,21 @@ struct ShiftModel<HashType<ValueType, Extras...>, Direction> {
     hash_type hash;
     char symbol;
 
-    ShiftModel(const hash_type hash,
+    Shift(const hash_type hash,
                const char symbol)
         : hash(hash),
           symbol(symbol)
     {
     }
 
-    ShiftModel()
+    Shift()
         : hash(),
           symbol('\0')
     {
     }
 
-    ShiftModel(const ShiftModel& other)
-        : ShiftModel(other.hash, other.symbol)
+    Shift(const Shift& other)
+        : Shift(other.hash, other.symbol)
     {
     }
 
@@ -395,17 +395,17 @@ struct ShiftModel<HashType<ValueType, Extras...>, Direction> {
     }
 
     __attribute__((visibility("default")))
-    friend bool operator>(const ShiftModel& lhs, const ShiftModel& rhs) {
+    friend bool operator>(const Shift& lhs, const Shift& rhs) {
         return lhs.hash > rhs.hash;
     }
 
     __attribute__((visibility("default")))
-    friend bool operator<(const ShiftModel& lhs, const ShiftModel& rhs) {
+    friend bool operator<(const Shift& lhs, const Shift& rhs) {
         return lhs.hash < rhs.hash;
     }
 
     __attribute__((visibility("default")))
-    friend bool operator==(const ShiftModel& lhs, const ShiftModel& rhs) {
+    friend bool operator==(const Shift& lhs, const Shift& rhs) {
         return lhs.hash == rhs.hash;
     }
 };
@@ -415,8 +415,8 @@ template <template<class, class...> class HashType, class ValueType, class... Ex
 __attribute__((visibility("default")))
 inline std::ostream&
 operator<<(std::ostream& os,
-           const ShiftModel<HashType<ValueType, Extras...>, Direction>& shift) {
-    os << "<ShiftModel"
+           const Shift<HashType<ValueType, Extras...>, Direction>& shift) {
+    os << "<Shift"
        << " hash=" << shift.hash
        << " symbol=" << shift.symbol
        << " direction=" << shift.direction
@@ -490,23 +490,37 @@ operator<<(std::ostream& os, const Partitioned<ValueType>& p) {
 }
 
 
-typedef boink::hashing::HashModel<uint64_t> Hash;
-typedef boink::hashing::CanonicalModel<uint64_t> Canonical;
 
-typedef boink::hashing::KmerModel<boink::hashing::HashModel<uint64_t>> Kmer;
-typedef boink::hashing::KmerModel<boink::hashing::CanonicalModel<uint64_t>> CanonicalKmer;
+typedef boink::hashing::Partitioned<boink::hashing::Hash<>> Unikmer;
+typedef boink::hashing::Partitioned<boink::hashing::Canonical<>> CanonicalUnikmer;
 
-typedef boink::hashing::Partitioned<boink::hashing::Hash> Unikmer;
-typedef boink::hashing::Partitioned<boink::hashing::Canonical> CanonicalUnikmer;
+typedef boink::hashing::Wmer<boink::hashing::Hash<>, boink::hashing::Unikmer> UnikmerWmer;
+typedef boink::hashing::Wmer<boink::hashing::Canonical<>, boink::hashing::CanonicalUnikmer> CanonicalUnikmerWmer;
 
-typedef boink::hashing::WmerModel<boink::hashing::Hash, boink::hashing::Unikmer> UnikmerWmer;
-typedef boink::hashing::WmerModel<boink::hashing::Canonical, boink::hashing::CanonicalUnikmer> CanonicalUnikmerWmer;
-
-typedef boink::hashing::ShiftModel<boink::hashing::Hash, boink::hashing::DIR_LEFT> LeftShift;
-typedef boink::hashing::ShiftModel<boink::hashing::Hash, boink::hashing::DIR_RIGHT> RightShift;
-typedef boink::hashing::ShiftModel<boink::hashing::Canonical, boink::hashing::DIR_LEFT> LeftCanonicalShift;
-typedef boink::hashing::ShiftModel<boink::hashing::Canonical, boink::hashing::DIR_RIGHT> RightCanonicalShift;
+typedef boink::hashing::Shift<boink::hashing::Hash<>, boink::hashing::DIR_LEFT> LeftShift;
+typedef boink::hashing::Shift<boink::hashing::Hash<>, boink::hashing::DIR_RIGHT> RightShift;
+typedef boink::hashing::Shift<boink::hashing::Canonical<>, boink::hashing::DIR_LEFT> LeftCanonicalShift;
+typedef boink::hashing::Shift<boink::hashing::Canonical<>, boink::hashing::DIR_RIGHT> RightCanonicalShift;
 
 }
+
+extern template class boink::hashing::Hash<uint64_t>;
+extern template class boink::hashing::Canonical<boink::hashing::Hash<uint64_t>>;
+
+extern template class boink::hashing::Kmer<boink::hashing::Hash<uint64_t>>;
+extern template class boink::hashing::Kmer<boink::hashing::Canonical<uint64_t>>;
+
+extern template class boink::hashing::Kmer<boink::hashing::UnikmerWmer>;
+extern template class boink::hashing::Kmer<boink::hashing::CanonicalUnikmerWmer>;
+
+extern template class boink::hashing::Wmer<boink::hashing::Hash<uint64_t>, boink::hashing::Unikmer>;
+extern template class boink::hashing::Wmer<boink::hashing::Canonical<uint64_t>, boink::hashing::CanonicalUnikmer>;
+
+extern template class boink::hashing::Shift<boink::hashing::Hash<uint64_t>, boink::hashing::DIR_LEFT>;
+extern template class boink::hashing::Shift<boink::hashing::Hash<uint64_t>, boink::hashing::DIR_RIGHT>;
+extern template class boink::hashing::Shift<boink::hashing::Canonical<uint64_t>, boink::hashing::DIR_LEFT>;
+extern template class boink::hashing::Shift<boink::hashing::Canonical<uint64_t>, boink::hashing::DIR_RIGHT>;
+
+
 
 #endif

--- a/include/boink/hashing/hashextender.hh
+++ b/include/boink/hashing/hashextender.hh
@@ -76,8 +76,8 @@ public:
     typedef typename extension_policy::kmer_type    kmer_type;
     typedef typename extension_policy::alphabet     alphabet;
 
-    typedef ShiftModel<hash_type, DIR_LEFT>         shift_left_type;
-    typedef ShiftModel<hash_type, DIR_RIGHT>        shift_right_type;
+    typedef Shift<hash_type, DIR_LEFT>         shift_left_type;
+    typedef Shift<hash_type, DIR_RIGHT>        shift_right_type;
 
     using extension_policy::K;
 
@@ -265,11 +265,11 @@ public:
     typedef typename hash_type::value_type   value_type;
 
     template<bool Dir>
-        using shift_type = ShiftModel<hash_type, Dir>;
+        using shift_type = Shift<hash_type, Dir>;
 
-    typedef ShiftModel<hash_type, DIR_LEFT>  shift_left_type;
-    typedef ShiftModel<hash_type, DIR_RIGHT> shift_right_type;
-    typedef KmerModel<hash_type>             kmer_type;
+    typedef Shift<hash_type, DIR_LEFT>  shift_left_type;
+    typedef Shift<hash_type, DIR_RIGHT> shift_right_type;
+    typedef Kmer<hash_type>             kmer_type;
     typedef typename ShifterType::alphabet   alphabet;
 
     using shifter_type::K;

--- a/include/boink/hashing/hashextender.hh
+++ b/include/boink/hashing/hashextender.hh
@@ -406,8 +406,8 @@ public:
     }
 };
 
-typedef HashExtender<DefaultExtensionPolicy<FwdRollingShifter>> FwdRollingExtender;
-typedef HashExtender<DefaultExtensionPolicy<CanRollingShifter>> CanRollingExtender;
+typedef HashExtender<DefaultExtensionPolicy<FwdLemireShifter>> FwdRollingExtender;
+typedef HashExtender<DefaultExtensionPolicy<CanLemireShifter>> CanRollingExtender;
 
 typedef HashExtender<FwdUnikmerShifter> FwdUnikmerExtender;
 typedef HashExtender<CanUnikmerShifter> CanUnikmerExtender;
@@ -438,11 +438,11 @@ template<typename ShifterType>
     using extender_selector_t = typename extender_selector<ShifterType>::type;
 
 
-extern template class DefaultExtensionPolicy<FwdRollingShifter>;
-extern template class DefaultExtensionPolicy<CanRollingShifter>;
+extern template class DefaultExtensionPolicy<FwdLemireShifter>;
+extern template class DefaultExtensionPolicy<CanLemireShifter>;
 
-extern template class HashExtender<DefaultExtensionPolicy<FwdRollingShifter>>;
-extern template class HashExtender<DefaultExtensionPolicy<CanRollingShifter>>;
+extern template class HashExtender<DefaultExtensionPolicy<FwdLemireShifter>>;
+extern template class HashExtender<DefaultExtensionPolicy<CanLemireShifter>>;
 
 extern template class HashExtender<FwdUnikmerShifter>;
 extern template class HashExtender<CanUnikmerShifter>;

--- a/include/boink/hashing/hashshifter.hh
+++ b/include/boink/hashing/hashshifter.hh
@@ -193,8 +193,8 @@ public:
 extern template class HashShifter<FwdLemirePolicy>;
 extern template class HashShifter<CanLemirePolicy>;
 
-typedef HashShifter<FwdLemirePolicy> FwdRollingShifter;
-typedef HashShifter<CanLemirePolicy> CanRollingShifter;
+typedef HashShifter<FwdLemirePolicy> FwdLemireShifter;
+typedef HashShifter<CanLemirePolicy> CanLemireShifter;
 
 } // boink
 

--- a/include/boink/hashing/kmeriterator.hh
+++ b/include/boink/hashing/kmeriterator.hh
@@ -141,8 +141,8 @@ public:
 };
 
 
-extern template class KmerIterator<FwdRollingShifter>;
-extern template class KmerIterator<CanRollingShifter>;
+extern template class KmerIterator<FwdLemireShifter>;
+extern template class KmerIterator<CanLemireShifter>;
 
 extern template class KmerIterator<FwdUnikmerShifter>;
 extern template class KmerIterator<CanUnikmerShifter>;

--- a/include/boink/hashing/rollinghashshifter.hh
+++ b/include/boink/hashing/rollinghashshifter.hh
@@ -44,9 +44,9 @@ protected:
 };
 
 template<>
-struct RollingHashShifterBase<CanonicalModel<uint64_t>> {
+struct RollingHashShifterBase<Canonical<uint64_t>> {
 protected:
-    typedef typename CanonicalModel<uint64_t>::value_type value_type;
+    typedef typename Canonical<uint64_t>::value_type value_type;
 
     CyclicHash<value_type> hasher;
     CyclicHash<value_type> rc_hasher;
@@ -67,7 +67,7 @@ public:
 
     typedef HashType                       hash_type;
     typedef typename hash_type::value_type value_type;
-    typedef KmerModel<hash_type>           kmer_type;
+    typedef Kmer<hash_type>           kmer_type;
     typedef Alphabet                       alphabet;
     static constexpr bool has_kmer_span = false;
 
@@ -133,33 +133,33 @@ protected:
 
 
 template<>
-inline RollingHashShifter<CanonicalModel<uint64_t>>
+inline RollingHashShifter<Canonical<uint64_t>>
 ::RollingHashShifter(uint16_t K)
-    : RollingHashShifterBase<CanonicalModel<uint64_t>>(K),
+    : RollingHashShifterBase<Canonical<uint64_t>>(K),
       K(K)
 {
 }
 
 template<>
-inline RollingHashShifter<CanonicalModel<uint64_t>>
+inline RollingHashShifter<Canonical<uint64_t>>
 ::RollingHashShifter(const RollingHashShifter& other)
-    : RollingHashShifterBase<CanonicalModel<uint64_t>>(other.K),
+    : RollingHashShifterBase<Canonical<uint64_t>>(other.K),
       K(other.K)
 {
 }
 
 
 template<>
-inline CanonicalModel<uint64_t>
-RollingHashShifter<CanonicalModel<uint64_t>>
+inline Canonical<uint64_t>
+RollingHashShifter<Canonical<uint64_t>>
 ::get_impl() {
     return {hasher.hashvalue, rc_hasher.hashvalue};
 }
 
 template<>
 template<class It>
-inline CanonicalModel<uint64_t>
-RollingHashShifter<CanonicalModel<uint64_t>>
+inline Canonical<uint64_t>
+RollingHashShifter<Canonical<uint64_t>>
 ::hash_base_impl(It begin, It end) {
 
     hasher.reset();
@@ -185,8 +185,8 @@ RollingHashShifter<CanonicalModel<uint64_t>>
 
 
 template<>
-inline CanonicalModel<uint64_t>
-RollingHashShifter<CanonicalModel<uint64_t>>
+inline Canonical<uint64_t>
+RollingHashShifter<Canonical<uint64_t>>
 ::hash_base_impl(const char * sequence) {
     hasher.reset();
     rc_hasher.reset();
@@ -204,8 +204,8 @@ RollingHashShifter<CanonicalModel<uint64_t>>
 
 
 template<>
-inline CanonicalModel<uint64_t>
-RollingHashShifter<CanonicalModel<uint64_t>>
+inline Canonical<uint64_t>
+RollingHashShifter<Canonical<uint64_t>>
 ::shift_right_impl(const char& out, const char& in) {
     hasher.update(out, in);
     rc_hasher.reverse_update(alphabet::complement(in),
@@ -215,8 +215,8 @@ RollingHashShifter<CanonicalModel<uint64_t>>
 
 
 template<>
-inline CanonicalModel<uint64_t>
-RollingHashShifter<CanonicalModel<uint64_t>>
+inline Canonical<uint64_t>
+RollingHashShifter<Canonical<uint64_t>>
 ::shift_left_impl(const char& in, const char& out) {
     hasher.reverse_update(in, out);
     rc_hasher.update(alphabet::complement(out),
@@ -224,11 +224,11 @@ RollingHashShifter<CanonicalModel<uint64_t>>
     return get_impl();
 }
 
-typedef RollingHashShifter<HashModel<uint64_t>> FwdLemirePolicy;
-typedef RollingHashShifter<CanonicalModel<uint64_t>> CanLemirePolicy;
+typedef RollingHashShifter<Hash<uint64_t>> FwdLemirePolicy;
+typedef RollingHashShifter<Canonical<uint64_t>> CanLemirePolicy;
 
-extern template class RollingHashShifter<HashModel<uint64_t>>;
-extern template class RollingHashShifter<CanonicalModel<uint64_t>>;
+extern template class RollingHashShifter<Hash<uint64_t>>;
+extern template class RollingHashShifter<Canonical<uint64_t>>;
 
 } 
 

--- a/include/boink/hashing/rollinghashshifter.hh
+++ b/include/boink/hashing/rollinghashshifter.hh
@@ -28,30 +28,30 @@ namespace boink::hashing {
 
 
 template<class HashType>
-struct RollingHashShifterBase {
+struct LemireShifterPolicyBase {
 protected:
     typedef typename HashType::value_type value_type;
 
     CyclicHash<value_type> hasher;
 
-    explicit RollingHashShifterBase(uint16_t K)
+    explicit LemireShifterPolicyBase(uint16_t K)
         : hasher(K) {
         
         //std::cout << "END RollingBase(K) ctor " << this << std::endl;
     }
 
-    RollingHashShifterBase() = delete;
+    LemireShifterPolicyBase() = delete;
 };
 
 template<>
-struct RollingHashShifterBase<Canonical<uint64_t>> {
+struct LemireShifterPolicyBase<Canonical<uint64_t>> {
 protected:
     typedef typename Canonical<uint64_t>::value_type value_type;
 
     CyclicHash<value_type> hasher;
     CyclicHash<value_type> rc_hasher;
 
-    explicit RollingHashShifterBase(uint16_t K)
+    explicit LemireShifterPolicyBase(uint16_t K)
         : hasher(K),
           rc_hasher(K) {}
 };
@@ -59,9 +59,9 @@ protected:
 
 template<typename HashType,
          typename Alphabet = DNA_SIMPLE>
-class RollingHashShifter : public RollingHashShifterBase<HashType> {
+class LemireShifterPolicy : public LemireShifterPolicyBase<HashType> {
 
-    typedef Tagged<RollingHashShifter<HashType, Alphabet>> tagged_type;
+    typedef Tagged<LemireShifterPolicy<HashType, Alphabet>> tagged_type;
 
 public:
 
@@ -114,36 +114,36 @@ public:
 
 protected:
 
-    explicit RollingHashShifter(uint16_t K)
-        : RollingHashShifterBase<HashType>(K),
+    explicit LemireShifterPolicy(uint16_t K)
+        : LemireShifterPolicyBase<HashType>(K),
           K(K)
     {   
-        //std::cout << "END RollingHashShifter(K) ctor " << this << " / " << static_cast<RollingHashShifterBase<HashType>*>(this) << std::endl;
+        //std::cout << "END LemireShifterPolicy(K) ctor " << this << " / " << static_cast<LemireShifterPolicyBase<HashType>*>(this) << std::endl;
     }
 
-    explicit RollingHashShifter(const RollingHashShifter& other)
-        : RollingHashShifter(other.K)
+    explicit LemireShifterPolicy(const LemireShifterPolicy& other)
+        : LemireShifterPolicy(other.K)
     {
-        //std::cout << "END RollingHashShifter(other) ctor " << this << " / " << static_cast<RollingHashShifterBase<HashType>*>(this) << std::endl;
+        //std::cout << "END LemireShifterPolicy(other) ctor " << this << " / " << static_cast<LemireShifterPolicyBase<HashType>*>(this) << std::endl;
     }
 
-    RollingHashShifter() = delete;
+    LemireShifterPolicy() = delete;
 
 };
 
 
 template<>
-inline RollingHashShifter<Canonical<uint64_t>>
-::RollingHashShifter(uint16_t K)
-    : RollingHashShifterBase<Canonical<uint64_t>>(K),
+inline LemireShifterPolicy<Canonical<uint64_t>>
+::LemireShifterPolicy(uint16_t K)
+    : LemireShifterPolicyBase<Canonical<uint64_t>>(K),
       K(K)
 {
 }
 
 template<>
-inline RollingHashShifter<Canonical<uint64_t>>
-::RollingHashShifter(const RollingHashShifter& other)
-    : RollingHashShifterBase<Canonical<uint64_t>>(other.K),
+inline LemireShifterPolicy<Canonical<uint64_t>>
+::LemireShifterPolicy(const LemireShifterPolicy& other)
+    : LemireShifterPolicyBase<Canonical<uint64_t>>(other.K),
       K(other.K)
 {
 }
@@ -151,7 +151,7 @@ inline RollingHashShifter<Canonical<uint64_t>>
 
 template<>
 inline Canonical<uint64_t>
-RollingHashShifter<Canonical<uint64_t>>
+LemireShifterPolicy<Canonical<uint64_t>>
 ::get_impl() {
     return {hasher.hashvalue, rc_hasher.hashvalue};
 }
@@ -159,7 +159,7 @@ RollingHashShifter<Canonical<uint64_t>>
 template<>
 template<class It>
 inline Canonical<uint64_t>
-RollingHashShifter<Canonical<uint64_t>>
+LemireShifterPolicy<Canonical<uint64_t>>
 ::hash_base_impl(It begin, It end) {
 
     hasher.reset();
@@ -186,7 +186,7 @@ RollingHashShifter<Canonical<uint64_t>>
 
 template<>
 inline Canonical<uint64_t>
-RollingHashShifter<Canonical<uint64_t>>
+LemireShifterPolicy<Canonical<uint64_t>>
 ::hash_base_impl(const char * sequence) {
     hasher.reset();
     rc_hasher.reset();
@@ -205,7 +205,7 @@ RollingHashShifter<Canonical<uint64_t>>
 
 template<>
 inline Canonical<uint64_t>
-RollingHashShifter<Canonical<uint64_t>>
+LemireShifterPolicy<Canonical<uint64_t>>
 ::shift_right_impl(const char& out, const char& in) {
     hasher.update(out, in);
     rc_hasher.reverse_update(alphabet::complement(in),
@@ -216,7 +216,7 @@ RollingHashShifter<Canonical<uint64_t>>
 
 template<>
 inline Canonical<uint64_t>
-RollingHashShifter<Canonical<uint64_t>>
+LemireShifterPolicy<Canonical<uint64_t>>
 ::shift_left_impl(const char& in, const char& out) {
     hasher.reverse_update(in, out);
     rc_hasher.update(alphabet::complement(out),
@@ -224,11 +224,11 @@ RollingHashShifter<Canonical<uint64_t>>
     return get_impl();
 }
 
-typedef RollingHashShifter<Hash<uint64_t>> FwdLemirePolicy;
-typedef RollingHashShifter<Canonical<uint64_t>> CanLemirePolicy;
+typedef LemireShifterPolicy<Hash<uint64_t>> FwdLemirePolicy;
+typedef LemireShifterPolicy<Canonical<uint64_t>> CanLemirePolicy;
 
-extern template class RollingHashShifter<Hash<uint64_t>>;
-extern template class RollingHashShifter<Canonical<uint64_t>>;
+extern template class LemireShifterPolicy<Hash<uint64_t>>;
+extern template class LemireShifterPolicy<Canonical<uint64_t>>;
 
 } 
 

--- a/include/boink/hashing/ukhs.hh
+++ b/include/boink/hashing/ukhs.hh
@@ -122,8 +122,8 @@ class UnikmerShifterPolicy<ShiftPolicy<HashType, Alphabet>> : public KmerSpan {
      *             size_t   partition
      * 
      * At least, assuming value_type is uint64_t, which it basically
-     * always is. That is, hash_type follows WmerModel<uint64_t, Unikmer>, 
-     * and kmer_type will have WmerModel as its hash.
+     * always is. That is, hash_type follows Wmer<uint64_t, Unikmer>, 
+     * and kmer_type will have Wmer as its hash.
      *
      * There will usually be only one associated unikmer
      * for a single k-mer. Sometimes, however, a few unikmers
@@ -152,15 +152,15 @@ public:
     // Shared typedefs
     typedef UKHS<base_shifter_type>                             ukhs_type;
     typedef typename ukhs_type::Unikmer                         minimizer_type;
-    typedef WmerModel<typename ukhs_type::hash_type,
+    typedef Wmer<typename ukhs_type::hash_type,
                       typename ukhs_type::Unikmer>              hash_type;
-    typedef KmerModel<hash_type>                                kmer_type;
+    typedef Kmer<hash_type>                                kmer_type;
     typedef typename hash_type::value_type                      value_type;
     typedef Alphabet                                            alphabet;
 
     typedef hash_type                                           wmer_type;
-    typedef ShiftModel<wmer_type, DIR_LEFT>                     shift_left_type;
-    typedef ShiftModel<wmer_type, DIR_RIGHT>                    shift_right_type;
+    typedef Shift<wmer_type, DIR_LEFT>                     shift_left_type;
+    typedef Shift<wmer_type, DIR_RIGHT>                    shift_right_type;
 
     static constexpr bool has_kmer_span = true;
 
@@ -552,8 +552,8 @@ struct UnikmerLemirePolicy : public UnikmerShifterPolicy<RollingHashShifter<Hash
         using UnikmerShifterPolicy<RollingHashShifter<HashType, Alphabet>>::UnikmerShifterPolicy;
 };
 
-typedef UnikmerLemirePolicy<HashModel<uint64_t>> FwdUnikmerPolicy;
-typedef UnikmerLemirePolicy<CanonicalModel<uint64_t>> CanUnikmerPolicy;
+typedef UnikmerLemirePolicy<Hash<uint64_t>> FwdUnikmerPolicy;
+typedef UnikmerLemirePolicy<Canonical<uint64_t>> CanUnikmerPolicy;
 
 extern template class UKHS<FwdRollingShifter>;
 extern template class UKHS<CanRollingShifter>;
@@ -561,8 +561,8 @@ extern template class UKHS<CanRollingShifter>;
 extern template class UnikmerShifterPolicy<FwdLemirePolicy>;
 extern template class UnikmerShifterPolicy<CanLemirePolicy>;
 
-extern template class UnikmerLemirePolicy<HashModel<uint64_t>, DNA_SIMPLE>;
-extern template class UnikmerLemirePolicy<CanonicalModel<uint64_t>, DNA_SIMPLE>;
+extern template class UnikmerLemirePolicy<Hash<uint64_t>, DNA_SIMPLE>;
+extern template class UnikmerLemirePolicy<Canonical<uint64_t>, DNA_SIMPLE>;
 
 }
 

--- a/include/boink/hashing/ukhs.hh
+++ b/include/boink/hashing/ukhs.hh
@@ -546,17 +546,17 @@ protected:
  * @tparam Alphabet 
  */
 template <typename HashType, typename Alphabet=DNA_SIMPLE>
-struct UnikmerLemirePolicy : public UnikmerShifterPolicy<RollingHashShifter<HashType, Alphabet>>
+struct UnikmerLemirePolicy : public UnikmerShifterPolicy<LemireShifterPolicy<HashType, Alphabet>>
 {
     protected:
-        using UnikmerShifterPolicy<RollingHashShifter<HashType, Alphabet>>::UnikmerShifterPolicy;
+        using UnikmerShifterPolicy<LemireShifterPolicy<HashType, Alphabet>>::UnikmerShifterPolicy;
 };
 
 typedef UnikmerLemirePolicy<Hash<uint64_t>> FwdUnikmerPolicy;
 typedef UnikmerLemirePolicy<Canonical<uint64_t>> CanUnikmerPolicy;
 
-extern template class UKHS<FwdRollingShifter>;
-extern template class UKHS<CanRollingShifter>;
+extern template class UKHS<FwdLemireShifter>;
+extern template class UKHS<CanLemireShifter>;
 
 extern template class UnikmerShifterPolicy<FwdLemirePolicy>;
 extern template class UnikmerShifterPolicy<CanLemirePolicy>;

--- a/include/boink/interface.hh
+++ b/include/boink/interface.hh
@@ -81,22 +81,4 @@ template bool operator!=(const std::STLTYPE< TTYPE >::iterator&,                
                          const std::STLTYPE< TTYPE >::iterator&);                 \
 }
 
-
-template class boink::hashing::HashModel<uint64_t>;
-template class boink::hashing::CanonicalModel<boink::hashing::HashModel<uint64_t>>;
-
-template class boink::hashing::Partitioned<boink::hashing::HashModel<uint64_t>>;
-template class boink::hashing::Partitioned<boink::hashing::CanonicalModel<uint64_t>>;
-
-template class boink::hashing::KmerModel<boink::hashing::HashModel<uint64_t>>;
-template class boink::hashing::KmerModel<boink::hashing::CanonicalModel<boink::hashing::HashModel<uint64_t>>>;
-template class boink::hashing::KmerModel<boink::hashing::UnikmerWmer>;
-template class boink::hashing::KmerModel<boink::hashing::CanonicalUnikmerWmer>;
-
-template class boink::hashing::ShiftModel<boink::hashing::Hash, boink::hashing::DIR_LEFT>;
-template class boink::hashing::ShiftModel<boink::hashing::Hash, boink::hashing::DIR_RIGHT>;
-template class boink::hashing::ShiftModel<boink::hashing::Canonical, boink::hashing::DIR_LEFT>;
-template class boink::hashing::ShiftModel<boink::hashing::Canonical, boink::hashing::DIR_RIGHT>;
-
-
 #endif

--- a/include/boink/meta.hh
+++ b/include/boink/meta.hh
@@ -21,7 +21,7 @@
     typedef typename shifter_type::hash_type         hash_type; \
 	typedef typename hash_type::value_type           value_type; \
     typedef typename shifter_type::kmer_type         kmer_type; \
-    template<bool Dir> using shift_type = hashing::ShiftModel<hash_type, Dir>; \
+    template<bool Dir> using shift_type = hashing::Shift<hash_type, Dir>; \
     typedef std::pair<std::vector<kmer_type>, \
                       std::vector<kmer_type>>         neighbor_pair_type;\
     typedef std::pair<std::vector<shift_type<hashing::DIR_LEFT>>,\

--- a/include/boink/minimizers.hh
+++ b/include/boink/minimizers.hh
@@ -253,8 +253,8 @@ struct WKMinimizer {
 };
 
 extern template class InteriorMinimizer<uint64_t>;
-extern template class WKMinimizer<hashing::FwdRollingShifter>;
-extern template class WKMinimizer<hashing::CanRollingShifter>;
+extern template class WKMinimizer<hashing::FwdLemireShifter>;
+extern template class WKMinimizer<hashing::CanLemireShifter>;
 
 }
 

--- a/include/boink/signatures/ukhs_signature.hh
+++ b/include/boink/signatures/ukhs_signature.hh
@@ -181,20 +181,20 @@ struct UnikmerSignature {
 
 };
 
-extern template class signatures::UnikmerSignature<storage::BitStorage, hashing::HashModel<uint64_t>>;
-extern template class signatures::UnikmerSignature<storage::BitStorage, hashing::CanonicalModel<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::BitStorage, hashing::Hash<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::BitStorage, hashing::Canonical<uint64_t>>;
 
-extern template class signatures::UnikmerSignature<storage::SparseppSetStorage, hashing::HashModel<uint64_t>>;
-extern template class signatures::UnikmerSignature<storage::SparseppSetStorage, hashing::CanonicalModel<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::SparseppSetStorage, hashing::Hash<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::SparseppSetStorage, hashing::Canonical<uint64_t>>;
 
-extern template class signatures::UnikmerSignature<storage::ByteStorage, hashing::HashModel<uint64_t>>;
-extern template class signatures::UnikmerSignature<storage::ByteStorage, hashing::CanonicalModel<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::ByteStorage, hashing::Hash<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::ByteStorage, hashing::Canonical<uint64_t>>;
 
-extern template class signatures::UnikmerSignature<storage::NibbleStorage, hashing::HashModel<uint64_t>>;
-extern template class signatures::UnikmerSignature<storage::NibbleStorage, hashing::CanonicalModel<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::NibbleStorage, hashing::Hash<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::NibbleStorage, hashing::Canonical<uint64_t>>;
 
-extern template class signatures::UnikmerSignature<storage::QFStorage, hashing::HashModel<uint64_t>>;
-extern template class signatures::UnikmerSignature<storage::QFStorage, hashing::CanonicalModel<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::QFStorage, hashing::Hash<uint64_t>>;
+extern template class signatures::UnikmerSignature<storage::QFStorage, hashing::Canonical<uint64_t>>;
 
 
 

--- a/include/boink/traversal.hh
+++ b/include/boink/traversal.hh
@@ -10,6 +10,7 @@
 #ifndef BOINK_ASSEMBLY_HH
 #define BOINK_ASSEMBLY_HH
 
+#include "boink/boink.hh"
 #include "boink/hashing/kmeriterator.hh"
 #include "boink/hashing/hashextender.hh"
 #include "boink/hashing/canonical.hh"
@@ -125,7 +126,6 @@ public:
                 return start;
             }
         }
-
     };
 
     template<bool Dir = hashing::DIR_RIGHT, typename Dummy = void>
@@ -147,6 +147,19 @@ public:
         const std::string glue(const WalkImpl<hashing::DIR_LEFT>& left) const {
             return left.to_string() + this->to_string().substr(start.kmer.size());
         }
+
+        const std::string glue(const WalkImpl<hashing::DIR_RIGHT>& right) const {
+            return this->to_string() + right.to_string().substr(start.kmer.size());
+        }
+
+        const char retreat_symbol() const {
+            size_t position = path.size();
+            if (position < start.kmer.size()) {
+                return start.kmer[position];
+            } else {
+                return path[position - start.kmer.size()].symbol;
+            }
+        }
     };
 
     template<typename Dummy>
@@ -154,6 +167,15 @@ public:
         using WalkBase<hashing::DIR_LEFT>::start;
         using WalkBase<hashing::DIR_LEFT>::path;
         using WalkBase<hashing::DIR_LEFT>::end_state;
+
+        const char retreat_symbol() const {
+            size_t position = path.size();
+            if (position < start.kmer.size()) {
+                return start.kmer[start.kmer.size() - position - 1];
+            } else {
+                return path[position - start.kmer.size()].symbol;
+            }
+        }   
 
         const std::string to_string() const {
             std::string str(0, ' ');
@@ -181,6 +203,7 @@ public:
         using walk_type::to_string;
         using walk_type::head;
         using walk_type::tail;
+        using walk_type::retreat_symbol;
         using walk_type::glue;
     };
 

--- a/include/boink/traversal.hh
+++ b/include/boink/traversal.hh
@@ -87,7 +87,7 @@ public:
     typedef typename hash_type::value_type          value_type;
 
     template<bool Dir>
-        using shift_type = hashing::ShiftModel<hash_type, Dir>;
+        using shift_type = hashing::Shift<hash_type, Dir>;
     typedef typename extender_type::shift_left_type  shift_left_type;
     typedef typename extender_type::shift_right_type shift_right_type;
 
@@ -112,7 +112,7 @@ public:
     template<bool Dir>
     struct WalkBase {
         kmer_type                                        start;
-        std::vector<hashing::ShiftModel<hash_type, Dir>> path;
+        std::vector<hashing::Shift<hash_type, Dir>> path;
         TraversalState::State                            end_state;
 
         const hash_type head() const {

--- a/include/boink/traversal.hh
+++ b/include/boink/traversal.hh
@@ -44,7 +44,7 @@ typedef std::vector<std::string> StringVector;
  * STOP_FWD: there are no neighbors in this direction.
  * DECISION_FWD: there is more than one neighbor.
  * STOP_SEEN: there is a single neighbor but it has been seen.
- * DECISION_RC: There is a single neighbor, but it is a decision in the other direction.
+ * DECISION_BKW: There is a single neighbor, but it is a decision in the other direction.
  * STOP_MASKED: There is a single neighbor, but it is masked.
  * BAD_SEED: The node you tried to start at does not exist.
  * GRAPH_ERROR: The graph is structural unsound (basically a panic).
@@ -55,9 +55,8 @@ namespace TraversalState {
 
     enum State {
         STOP_FWD,
-        STOP_RC,
         DECISION_FWD,
-        DECISION_RC,
+        DECISION_BKW,
         STOP_SEEN,
         STOP_MASKED,
         BAD_SEED,
@@ -661,7 +660,7 @@ public:
             if (out_degree() > 1) {
                 pdebug("Stop: reverse d-node");
                 walk.path.pop_back();
-                walk.end_state = State::DECISION_RC;
+                walk.end_state = State::DECISION_BKW;
                 this->seen.erase(this->get().value());
                 return std::move(walk);
             }
@@ -714,7 +713,7 @@ public:
         while (1) {
             if (in_degree() > 1) {
                 walk.path.pop_back();
-                walk.end_state = State::DECISION_RC;
+                walk.end_state = State::DECISION_BKW;
                 this->seen.erase(this->get().value());
                 return std::move(walk);
             }

--- a/src/boink/cdbg/cdbg.cc
+++ b/src/boink/cdbg/cdbg.cc
@@ -14,18 +14,18 @@
 
 namespace boink {
 
-template class cdbg::cDBG<dBG<storage::BitStorage, hashing::FwdRollingShifter>>;
-template class cdbg::cDBG<dBG<storage::BitStorage, hashing::CanRollingShifter>>;
+template class cdbg::cDBG<dBG<storage::BitStorage, hashing::FwdLemireShifter>>;
+template class cdbg::cDBG<dBG<storage::BitStorage, hashing::CanLemireShifter>>;
 
-template class cdbg::cDBG<dBG<storage::SparseppSetStorage, hashing::FwdRollingShifter>>;
-template class cdbg::cDBG<dBG<storage::SparseppSetStorage, hashing::CanRollingShifter>>;
+template class cdbg::cDBG<dBG<storage::SparseppSetStorage, hashing::FwdLemireShifter>>;
+template class cdbg::cDBG<dBG<storage::SparseppSetStorage, hashing::CanLemireShifter>>;
 
-template class cdbg::cDBG<dBG<storage::ByteStorage, hashing::FwdRollingShifter>>;
-template class cdbg::cDBG<dBG<storage::ByteStorage, hashing::CanRollingShifter>>;
+template class cdbg::cDBG<dBG<storage::ByteStorage, hashing::FwdLemireShifter>>;
+template class cdbg::cDBG<dBG<storage::ByteStorage, hashing::CanLemireShifter>>;
 
-template class cdbg::cDBG<dBG<storage::NibbleStorage, hashing::FwdRollingShifter>>;
-template class cdbg::cDBG<dBG<storage::NibbleStorage, hashing::CanRollingShifter>>;
+template class cdbg::cDBG<dBG<storage::NibbleStorage, hashing::FwdLemireShifter>>;
+template class cdbg::cDBG<dBG<storage::NibbleStorage, hashing::CanLemireShifter>>;
 
-template class cdbg::cDBG<dBG<storage::QFStorage, hashing::FwdRollingShifter>>;
-template class cdbg::cDBG<dBG<storage::QFStorage, hashing::CanRollingShifter>>;
+template class cdbg::cDBG<dBG<storage::QFStorage, hashing::FwdLemireShifter>>;
+template class cdbg::cDBG<dBG<storage::QFStorage, hashing::CanLemireShifter>>;
 }

--- a/src/boink/cdbg/compactor.cc
+++ b/src/boink/cdbg/compactor.cc
@@ -11,9 +11,9 @@
 #include "boink/hashing/rollinghashshifter.hh"
 
 
-template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::SparseppSetStorage, boink::hashing::FwdRollingShifter>>;
-template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::BitStorage, boink::hashing::FwdRollingShifter>>;
-template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::ByteStorage, boink::hashing::FwdRollingShifter>>;
-template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::NibbleStorage, boink::hashing::FwdRollingShifter>>;
-template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::QFStorage, boink::hashing::FwdRollingShifter>>;
+template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::SparseppSetStorage, boink::hashing::FwdLemireShifter>>;
+template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::BitStorage, boink::hashing::FwdLemireShifter>>;
+template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::ByteStorage, boink::hashing::FwdLemireShifter>>;
+template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::NibbleStorage, boink::hashing::FwdLemireShifter>>;
+template class boink::cdbg::StreamingCompactor<boink::dBG<boink::storage::QFStorage, boink::hashing::FwdLemireShifter>>;
 

--- a/src/boink/dbg.cc
+++ b/src/boink/dbg.cc
@@ -14,54 +14,54 @@
 
 namespace boink {
 
-    template class dBG<storage::BitStorage, hashing::FwdRollingShifter>;
-    template class dBG<storage::BitStorage, hashing::CanRollingShifter>;
+    template class dBG<storage::BitStorage, hashing::FwdLemireShifter>;
+    template class dBG<storage::BitStorage, hashing::CanLemireShifter>;
     template class dBG<storage::BitStorage, hashing::FwdUnikmerShifter>;
     template class dBG<storage::BitStorage, hashing::CanUnikmerShifter>;
 
-    template class dBG<storage::SparseppSetStorage, hashing::FwdRollingShifter>;
-    template class dBG<storage::SparseppSetStorage, hashing::CanRollingShifter>;
+    template class dBG<storage::SparseppSetStorage, hashing::FwdLemireShifter>;
+    template class dBG<storage::SparseppSetStorage, hashing::CanLemireShifter>;
     template class dBG<storage::SparseppSetStorage, hashing::FwdUnikmerShifter>;
     template class dBG<storage::SparseppSetStorage, hashing::CanUnikmerShifter>;
 
-    template class dBG<storage::ByteStorage, hashing::FwdRollingShifter>;
-    template class dBG<storage::ByteStorage, hashing::CanRollingShifter>;
+    template class dBG<storage::ByteStorage, hashing::FwdLemireShifter>;
+    template class dBG<storage::ByteStorage, hashing::CanLemireShifter>;
     template class dBG<storage::ByteStorage, hashing::FwdUnikmerShifter>;
     template class dBG<storage::ByteStorage, hashing::CanUnikmerShifter>;
 
-    template class dBG<storage::NibbleStorage, hashing::FwdRollingShifter>;
-    template class dBG<storage::NibbleStorage, hashing::CanRollingShifter>;
+    template class dBG<storage::NibbleStorage, hashing::FwdLemireShifter>;
+    template class dBG<storage::NibbleStorage, hashing::CanLemireShifter>;
     template class dBG<storage::NibbleStorage, hashing::FwdUnikmerShifter>;
     template class dBG<storage::NibbleStorage, hashing::CanUnikmerShifter>;
 
-    template class dBG<storage::QFStorage, hashing::FwdRollingShifter>;
-    template class dBG<storage::QFStorage, hashing::CanRollingShifter>;
+    template class dBG<storage::QFStorage, hashing::FwdLemireShifter>;
+    template class dBG<storage::QFStorage, hashing::CanLemireShifter>;
     template class dBG<storage::QFStorage, hashing::FwdUnikmerShifter>;
     template class dBG<storage::QFStorage, hashing::CanUnikmerShifter>;
 
 
-    template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::FwdRollingShifter>>;
-    template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::CanRollingShifter>>;
+    template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::FwdLemireShifter>>;
+    template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::CanLemireShifter>>;
     template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::FwdUnikmerShifter>>;
     template class hashing::KmerIterator<dBG<storage::BitStorage, hashing::CanUnikmerShifter>>;
 
-    template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::FwdRollingShifter>>;
-    template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::CanRollingShifter>>;
+    template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::FwdLemireShifter>>;
+    template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::CanLemireShifter>>;
     template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::FwdUnikmerShifter>>;
     template class hashing::KmerIterator<dBG<storage::SparseppSetStorage, hashing::CanUnikmerShifter>>;
 
-    template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::FwdRollingShifter>>;
-    template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::CanRollingShifter>>;
+    template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::FwdLemireShifter>>;
+    template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::CanLemireShifter>>;
     template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::FwdUnikmerShifter>>;
     template class hashing::KmerIterator<dBG<storage::ByteStorage, hashing::CanUnikmerShifter>>;
 
-    template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::FwdRollingShifter>>;
-    template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::CanRollingShifter>>;
+    template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::FwdLemireShifter>>;
+    template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::CanLemireShifter>>;
     template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::FwdUnikmerShifter>>;
     template class hashing::KmerIterator<dBG<storage::NibbleStorage, hashing::CanUnikmerShifter>>;
 
-    template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::FwdRollingShifter>>;
-    template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::CanRollingShifter>>;
+    template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::FwdLemireShifter>>;
+    template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::CanLemireShifter>>;
     template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::FwdUnikmerShifter>>;
     template class hashing::KmerIterator<dBG<storage::QFStorage, hashing::CanUnikmerShifter>>;
 }

--- a/src/boink/hashing/canonical.cc
+++ b/src/boink/hashing/canonical.cc
@@ -9,25 +9,25 @@
 #include "boink/hashing/canonical.hh"
 
 
-/*
+
 namespace boink::hashing {
 
-template class HashModel<uint64_t>;
-template class CanonicalModel<HashModel<uint64_t>>;
+    template class boink::hashing::Hash<uint64_t>;
+    template class boink::hashing::Canonical<boink::hashing::Hash<uint64_t>>;
 
-template class KmerModel<HashModel<uint64_t>>;
-template class KmerModel<CanonicalModel<HashModel<uint64_t>>>;
+    template class boink::hashing::Kmer<boink::hashing::Hash<uint64_t>>;
+    template class boink::hashing::Kmer<boink::hashing::Canonical<uint64_t>>;
 
-template class KmerModel<UnikmerWmer>;
-template class KmerModel<CanonicalUnikmerWmer>;
+    template class boink::hashing::Kmer<boink::hashing::UnikmerWmer>;
+    template class boink::hashing::Kmer<boink::hashing::CanonicalUnikmerWmer>;
 
-template class WmerModel<Hash, Unikmer>;
-template class WmerModel<Canonical, CanonicalUnikmer>;
+    template class boink::hashing::Wmer<boink::hashing::Hash<uint64_t>, boink::hashing::Unikmer>;
+    template class boink::hashing::Wmer<boink::hashing::Canonical<uint64_t>, boink::hashing::CanonicalUnikmer>;
 
-template class ShiftModel<Hash, DIR_LEFT>;
-template class ShiftModel<Hash, DIR_RIGHT>;
-template class ShiftModel<Canonical, DIR_LEFT>;
-template class ShiftModel<Canonical, DIR_RIGHT>;
+    template class boink::hashing::Shift<boink::hashing::Hash<uint64_t>, boink::hashing::DIR_LEFT>;
+    template class boink::hashing::Shift<boink::hashing::Hash<uint64_t>, boink::hashing::DIR_RIGHT>;
+    template class boink::hashing::Shift<boink::hashing::Canonical<uint64_t>, boink::hashing::DIR_LEFT>;
+    template class boink::hashing::Shift<boink::hashing::Canonical<uint64_t>, boink::hashing::DIR_RIGHT>;
 
 }
-*/
+

--- a/src/boink/hashing/hashextender.cc
+++ b/src/boink/hashing/hashextender.cc
@@ -11,16 +11,16 @@
 
 namespace boink::hashing {
 
-    template class DefaultExtensionPolicy<FwdRollingShifter>;
-    template class DefaultExtensionPolicy<CanRollingShifter>;
+    template class DefaultExtensionPolicy<FwdLemireShifter>;
+    template class DefaultExtensionPolicy<CanLemireShifter>;
 
-    template class HashExtender<DefaultExtensionPolicy<FwdRollingShifter>>;
-    template HashExtender<DefaultExtensionPolicy<FwdRollingShifter>>::HashExtender(uint16_t);
-    template HashExtender<DefaultExtensionPolicy<FwdRollingShifter>>::HashExtender(const std::string&, uint16_t);
+    template class HashExtender<DefaultExtensionPolicy<FwdLemireShifter>>;
+    template HashExtender<DefaultExtensionPolicy<FwdLemireShifter>>::HashExtender(uint16_t);
+    template HashExtender<DefaultExtensionPolicy<FwdLemireShifter>>::HashExtender(const std::string&, uint16_t);
 
-    template class HashExtender<DefaultExtensionPolicy<CanRollingShifter>>;
-    template HashExtender<DefaultExtensionPolicy<CanRollingShifter>>::HashExtender(uint16_t);
-    template HashExtender<DefaultExtensionPolicy<CanRollingShifter>>::HashExtender(const std::string&, uint16_t);
+    template class HashExtender<DefaultExtensionPolicy<CanLemireShifter>>;
+    template HashExtender<DefaultExtensionPolicy<CanLemireShifter>>::HashExtender(uint16_t);
+    template HashExtender<DefaultExtensionPolicy<CanLemireShifter>>::HashExtender(const std::string&, uint16_t);
 
     template class HashExtender<FwdUnikmerShifter>;
     template class HashExtender<CanUnikmerShifter>;

--- a/src/boink/hashing/kmeriterator.cc
+++ b/src/boink/hashing/kmeriterator.cc
@@ -11,8 +11,8 @@
 
 namespace boink::hashing {
 
-    template class KmerIterator<FwdRollingShifter>;
-    template class KmerIterator<CanRollingShifter>;
+    template class KmerIterator<FwdLemireShifter>;
+    template class KmerIterator<CanLemireShifter>;
 
     template class KmerIterator<FwdUnikmerShifter>;
     template class KmerIterator<CanUnikmerShifter>;

--- a/src/boink/hashing/rollinghashshifter.cc
+++ b/src/boink/hashing/rollinghashshifter.cc
@@ -13,8 +13,8 @@ namespace boink {
 
 namespace hashing {
 
-template class RollingHashShifter<Hash<uint64_t>>;
-template class RollingHashShifter<Canonical<uint64_t>>;
+template class LemireShifterPolicy<Hash<uint64_t>>;
+template class LemireShifterPolicy<Canonical<uint64_t>>;
 
 }
 }

--- a/src/boink/hashing/rollinghashshifter.cc
+++ b/src/boink/hashing/rollinghashshifter.cc
@@ -13,8 +13,8 @@ namespace boink {
 
 namespace hashing {
 
-template class RollingHashShifter<HashModel<uint64_t>>;
-template class RollingHashShifter<CanonicalModel<uint64_t>>;
+template class RollingHashShifter<Hash<uint64_t>>;
+template class RollingHashShifter<Canonical<uint64_t>>;
 
 }
 }

--- a/src/boink/hashing/ukhs.cc
+++ b/src/boink/hashing/ukhs.cc
@@ -15,8 +15,8 @@
 
 namespace boink::hashing {
 
-    template class UKHS<FwdRollingShifter>;
-    template class UKHS<CanRollingShifter>;
+    template class UKHS<FwdLemireShifter>;
+    template class UKHS<CanLemireShifter>;
     template class UnikmerShifterPolicy<FwdLemirePolicy>;
     template class UnikmerShifterPolicy<CanLemirePolicy>;
     template class UnikmerLemirePolicy<Hash<uint64_t>, DNA_SIMPLE>;

--- a/src/boink/hashing/ukhs.cc
+++ b/src/boink/hashing/ukhs.cc
@@ -19,8 +19,8 @@ namespace boink::hashing {
     template class UKHS<CanRollingShifter>;
     template class UnikmerShifterPolicy<FwdLemirePolicy>;
     template class UnikmerShifterPolicy<CanLemirePolicy>;
-    template class UnikmerLemirePolicy<HashModel<uint64_t>, DNA_SIMPLE>;
-    template class UnikmerLemirePolicy<CanonicalModel<uint64_t>, DNA_SIMPLE>;
+    template class UnikmerLemirePolicy<Hash<uint64_t>, DNA_SIMPLE>;
+    template class UnikmerLemirePolicy<Canonical<uint64_t>, DNA_SIMPLE>;
 
     template<> template<>
     typename UnikmerShifterPolicy<FwdLemirePolicy>::hash_type

--- a/src/boink/minimizers.cc
+++ b/src/boink/minimizers.cc
@@ -12,7 +12,7 @@
 namespace boink {
 
 template class InteriorMinimizer<uint64_t>;
-template class WKMinimizer<hashing::FwdRollingShifter>;
-template class WKMinimizer<hashing::CanRollingShifter>;
+template class WKMinimizer<hashing::FwdLemireShifter>;
+template class WKMinimizer<hashing::CanLemireShifter>;
 
 }

--- a/src/boink/signatures/ukhs_signature.cc
+++ b/src/boink/signatures/ukhs_signature.cc
@@ -15,20 +15,20 @@
 
 namespace boink {
     
-    template class signatures::UnikmerSignature<storage::BitStorage, hashing::HashModel<uint64_t>>;
-    template class signatures::UnikmerSignature<storage::BitStorage, hashing::CanonicalModel<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::BitStorage, hashing::Hash<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::BitStorage, hashing::Canonical<uint64_t>>;
 
-    template class signatures::UnikmerSignature<storage::SparseppSetStorage, hashing::HashModel<uint64_t>>;
-    template class signatures::UnikmerSignature<storage::SparseppSetStorage, hashing::CanonicalModel<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::SparseppSetStorage, hashing::Hash<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::SparseppSetStorage, hashing::Canonical<uint64_t>>;
 
-    template class signatures::UnikmerSignature<storage::ByteStorage, hashing::HashModel<uint64_t>>;
-    template class signatures::UnikmerSignature<storage::ByteStorage, hashing::CanonicalModel<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::ByteStorage, hashing::Hash<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::ByteStorage, hashing::Canonical<uint64_t>>;
 
-    template class signatures::UnikmerSignature<storage::NibbleStorage, hashing::HashModel<uint64_t>>;
-    template class signatures::UnikmerSignature<storage::NibbleStorage, hashing::CanonicalModel<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::NibbleStorage, hashing::Hash<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::NibbleStorage, hashing::Canonical<uint64_t>>;
 
-    template class signatures::UnikmerSignature<storage::QFStorage, hashing::HashModel<uint64_t>>;
-    template class signatures::UnikmerSignature<storage::QFStorage, hashing::CanonicalModel<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::QFStorage, hashing::Hash<uint64_t>>;
+    template class signatures::UnikmerSignature<storage::QFStorage, hashing::Canonical<uint64_t>>;
 
 
 

--- a/src/boink/traversal.cc
+++ b/src/boink/traversal.cc
@@ -13,28 +13,28 @@
 
 namespace boink {
 
-    template class dBGWalker<dBG<storage::BitStorage, hashing::FwdRollingShifter>>;
-    template class dBGWalker<dBG<storage::BitStorage, hashing::CanRollingShifter>>;
+    template class dBGWalker<dBG<storage::BitStorage, hashing::FwdLemireShifter>>;
+    template class dBGWalker<dBG<storage::BitStorage, hashing::CanLemireShifter>>;
     template class dBGWalker<dBG<storage::BitStorage, hashing::FwdUnikmerShifter>>;
     template class dBGWalker<dBG<storage::BitStorage, hashing::CanUnikmerShifter>>;
 
-    template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::FwdRollingShifter>>;
-    template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::CanRollingShifter>>;
+    template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::FwdLemireShifter>>;
+    template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::CanLemireShifter>>;
     template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::FwdUnikmerShifter>>;
     template class dBGWalker<dBG<storage::SparseppSetStorage, hashing::CanUnikmerShifter>>;
 
-    template class dBGWalker<dBG<storage::ByteStorage, hashing::FwdRollingShifter>>;
-    template class dBGWalker<dBG<storage::ByteStorage, hashing::CanRollingShifter>>;
+    template class dBGWalker<dBG<storage::ByteStorage, hashing::FwdLemireShifter>>;
+    template class dBGWalker<dBG<storage::ByteStorage, hashing::CanLemireShifter>>;
     template class dBGWalker<dBG<storage::ByteStorage, hashing::FwdUnikmerShifter>>;
     template class dBGWalker<dBG<storage::ByteStorage, hashing::CanUnikmerShifter>>;
 
-    template class dBGWalker<dBG<storage::NibbleStorage, hashing::FwdRollingShifter>>;
-    template class dBGWalker<dBG<storage::NibbleStorage, hashing::CanRollingShifter>>;
+    template class dBGWalker<dBG<storage::NibbleStorage, hashing::FwdLemireShifter>>;
+    template class dBGWalker<dBG<storage::NibbleStorage, hashing::CanLemireShifter>>;
     template class dBGWalker<dBG<storage::NibbleStorage, hashing::FwdUnikmerShifter>>;
     template class dBGWalker<dBG<storage::NibbleStorage, hashing::CanUnikmerShifter>>;
 
-    template class dBGWalker<dBG<storage::QFStorage, hashing::FwdRollingShifter>>;
-    template class dBGWalker<dBG<storage::QFStorage, hashing::CanRollingShifter>>;
+    template class dBGWalker<dBG<storage::QFStorage, hashing::FwdLemireShifter>>;
+    template class dBGWalker<dBG<storage::QFStorage, hashing::CanLemireShifter>>;
     template class dBGWalker<dBG<storage::QFStorage, hashing::FwdUnikmerShifter>>;
     template class dBGWalker<dBG<storage::QFStorage, hashing::CanUnikmerShifter>>;
 

--- a/tests/test_cdbg.py
+++ b/tests/test_cdbg.py
@@ -13,7 +13,7 @@ import pytest
 from tests.utils import *
 
 from boink import libboink, nullptr
-from boink.hashing import FwdRollingShifter
+from boink.hashing import FwdLemireShifter
 
 import cppyy.ll
 cppyy.ll.set_signals_as_exception(True)
@@ -31,7 +31,7 @@ def compactor(ksize, graph, compactor_type):
     return compactor
 
 
-@using(ksize=15, length=100, hasher_type=FwdRollingShifter)
+@using(ksize=15, length=100, hasher_type=FwdLemireShifter)
 @exact_backends()
 class TestFindNewSegments:
 
@@ -292,7 +292,7 @@ class TestFindNewSegments:
         assert segments[5].length == len(mut) - (pivotR + 1)
 
 
-@using(ksize=15, length=100, hasher_type=FwdRollingShifter)
+@using(ksize=15, length=100, hasher_type=FwdLemireShifter)
 @exact_backends()
 class TestDecisionNodes(object):
 
@@ -468,7 +468,7 @@ class TestDecisionNodes(object):
         assert compactor.cdbg.n_unodes == 2
 
 
-@using(ksize=15, length=100, hasher_type=FwdRollingShifter)
+@using(ksize=15, length=100, hasher_type=FwdLemireShifter)
 class TestUnitigBuildExtend(object):
 
     def test_left_fork_unode_creation(self, ksize, length, graph, compactor,
@@ -707,7 +707,7 @@ class TestUnitigBuildExtend(object):
         assert compactor.cdbg.query_unode_end(graph.hash(left[-ksize:])) is None
 
 
-@using(hasher_type=FwdRollingShifter)
+@using(hasher_type=FwdLemireShifter)
 class TestUnitigSplit(object):
 
     def test_split_full_fwd(self, left_comb, right_comb, ksize, tip_length, n_branches,
@@ -1115,7 +1115,7 @@ class TestUnitigSplit(object):
         assert rbottom.left_end == graph.hash(bottom[L+2:L+2+ksize])
 
 
-@using(hasher_type=FwdRollingShifter)
+@using(hasher_type=FwdLemireShifter)
 class TestCircularUnitigs:
 
     @using(ksize=15,
@@ -1329,7 +1329,7 @@ class TestCircularUnitigs:
         print((' ' * (pivot+1)) + cycled_loop_unode.sequence)
 
 
-@using(hasher_type=FwdRollingShifter)
+@using(hasher_type=FwdLemireShifter)
 class TestBreadthFirstTraversal:
 
     @using(ksize=21, length=100)
@@ -1379,7 +1379,7 @@ class TestBreadthFirstTraversal:
         assert len(nodes) == 6
 
 
-@using(hasher_type=FwdRollingShifter)
+@using(hasher_type=FwdLemireShifter)
 class TestFindConnectedComponents:
 
     @using(ksize=21, length=100)

--- a/tests/test_cdbg.py
+++ b/tests/test_cdbg.py
@@ -469,6 +469,7 @@ class TestDecisionNodes(object):
 
 
 @using(ksize=15, length=100, hasher_type=FwdLemireShifter)
+@exact_backends()
 class TestUnitigBuildExtend(object):
 
     def test_left_fork_unode_creation(self, ksize, length, graph, compactor,
@@ -708,6 +709,7 @@ class TestUnitigBuildExtend(object):
 
 
 @using(hasher_type=FwdLemireShifter)
+@exact_backends()
 class TestUnitigSplit(object):
 
     def test_split_full_fwd(self, left_comb, right_comb, ksize, tip_length, n_branches,
@@ -1116,6 +1118,7 @@ class TestUnitigSplit(object):
 
 
 @using(hasher_type=FwdLemireShifter)
+@exact_backends()
 class TestCircularUnitigs:
 
     @using(ksize=15,
@@ -1380,6 +1383,7 @@ class TestBreadthFirstTraversal:
 
 
 @using(hasher_type=FwdLemireShifter)
+@exact_backends()
 class TestFindConnectedComponents:
 
     @using(ksize=21, length=100)

--- a/tests/test_dbg.py
+++ b/tests/test_dbg.py
@@ -9,7 +9,7 @@ import pytest
 from cppyy.gbl import std
 
 from .utils import *
-from boink.hashing import FwdRollingShifter, UKHS
+from boink.hashing import FwdLemireShifter, UKHS
 import pytest
 
 
@@ -261,7 +261,7 @@ def test_get_kmer_hashes(graph, ksize, length, linear_path):
 
 @using(ksize=[21, 31, 41], length=1000)
 def test_hashing_2(graph, linear_path, ksize):
-    ''' Graph.hash uses a stand alone hasher for RollingHashShifters,
+    ''' Graph.hash uses a stand alone hasher for LemireShifterPolicys,
     Graph.hashes uses a KmerIterator; check that they give the same
     results.'''
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -8,7 +8,7 @@
 import pytest
 from .utils import *
 from boink import libboink
-from boink.hashing import (FwdRollingShifter, CanRollingShifter, 
+from boink.hashing import (FwdLemireShifter, CanLemireShifter, 
                            FwdUnikmerShifter, CanUnikmerShifter,
                            extender_selector_t)
 
@@ -52,7 +52,7 @@ def test_extender_set_cursor(hasher, ksize):
 
 
 @using(ksize=27)
-@pytest.mark.parametrize('hasher_type', [FwdRollingShifter, CanRollingShifter], indirect=True)
+@pytest.mark.parametrize('hasher_type', [FwdLemireShifter, CanLemireShifter], indirect=True)
 def test_rolling_hash(hasher, ksize):
     seq = 'TCACCTGTGTTGTGCTACTTGCGGCGC'
 
@@ -161,8 +161,8 @@ def test_seq_too_large(hasher, ksize, hash_method):
 def test_canonical_rolling_hash(ksize, length, random_sequence):
     seq = random_sequence()
 
-    can_hasher = libboink.hashing.CanRollingShifter(ksize)
-    fwd_hasher = libboink.hashing.FwdRollingShifter(ksize)
+    can_hasher = libboink.hashing.CanLemireShifter(ksize)
+    fwd_hasher = libboink.hashing.FwdLemireShifter(ksize)
 
     for kmer in kmers(seq, ksize):
         rc_kmer = fwd_hasher.alphabet.reverse_complement(kmer)
@@ -231,7 +231,7 @@ def test_shift_right(hasher, ksize, length, random_sequence):
     assert exp == fwd_hashes
 
 
-@pytest.mark.parametrize('hasher_type', [FwdRollingShifter, CanRollingShifter], indirect=True)
+@pytest.mark.parametrize('hasher_type', [FwdLemireShifter, CanLemireShifter], indirect=True)
 @using(ksize=27)
 def test_kmeriterator_owner_init(hasher_type, ksize):
     hasher_type, _ = hasher_type
@@ -239,7 +239,7 @@ def test_kmeriterator_owner_init(hasher_type, ksize):
     assert it.first().value in known_hashes
 
 
-#@pytest.mark.parametrize('hasher_type', [FwdRollingShifter, CanRollingShifter], indirect=True)
+#@pytest.mark.parametrize('hasher_type', [FwdLemireShifter, CanLemireShifter], indirect=True)
 #@using(ksize=27)
 #def test_kmeriterator_nonowner_init(hasher, ksize, length, random_sequence):
 #    it = libboink.hashing.KmerIterator[type(hasher)](known_kmer, hasher.__smartptr__().get())
@@ -247,14 +247,14 @@ def test_kmeriterator_owner_init(hasher_type, ksize):
 #    assert hasher.get().value in known_hashes
 
 
-@pytest.mark.parametrize('hasher_type', [FwdRollingShifter, CanRollingShifter], indirect=True)
+@pytest.mark.parametrize('hasher_type', [FwdLemireShifter, CanLemireShifter], indirect=True)
 @using(ksize=27)
 def test_kmeriterator_proto_init(hasher, ksize):
     it = libboink.hashing.KmerIterator[type(hasher)](known_kmer, hasher)
     assert it.first().value in known_hashes
 
 
-@pytest.mark.parametrize('hasher_type', [FwdRollingShifter, CanRollingShifter], indirect=True)
+@pytest.mark.parametrize('hasher_type', [FwdLemireShifter, CanLemireShifter], indirect=True)
 def test_kmeriterator(hasher, ksize, length, random_sequence):
     s = random_sequence()
 
@@ -269,7 +269,7 @@ def test_kmeriterator(hasher, ksize, length, random_sequence):
     assert act == exp
 
 
-@pytest.mark.parametrize('hasher_type', [FwdRollingShifter, CanRollingShifter], indirect=True)
+@pytest.mark.parametrize('hasher_type', [FwdLemireShifter, CanLemireShifter], indirect=True)
 def test_kmeriterator_from_proto(hasher, ksize, length, random_sequence):
     s = random_sequence()
 
@@ -285,7 +285,7 @@ def test_kmeriterator_from_proto(hasher, ksize, length, random_sequence):
 
 
 
-@pytest.mark.parametrize('hasher_type', [FwdRollingShifter, CanRollingShifter], indirect=True)
+@pytest.mark.parametrize('hasher_type', [FwdLemireShifter, CanLemireShifter], indirect=True)
 def test_kmeriterator_hashextender(hasher, ksize, length, random_sequence):
     s = random_sequence()
     extender = extender_selector_t[type(hasher)](hasher)

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -66,7 +66,7 @@ def test_rolling_hash(hasher, ksize):
 
 @using(ksize=21, length=10000)
 def test_hashing_models_hash(hasher, ksize, random_sequence):
-    '''test that __hash__ on HashModel and CanonicalModel
+    '''test that __hash__ on Hash and Canonical
     yields the value attribute.
     '''
 

--- a/tests/test_solid_compactor.py
+++ b/tests/test_solid_compactor.py
@@ -31,7 +31,7 @@ def solid_compactor(graph, compactor, compactor_type, min_abund):
     return _solid_compactor
 
 
-@using(hasher_type=libboink.hashing.RollingHashShifter)
+@using(hasher_type=libboink.hashing.LemireShifterPolicy)
 class TestFindSolidSegments:
 
     @using(ksize=21, length=100, min_abund=2)

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -150,7 +150,7 @@ class TestDecisions:
         assert branch == path
         assert graph.left_degree(path[:ksize]) == 1
         assert graph.right_degree(path[:ksize]) == 1
-        assert lwalk.end_state == STATES.DECISION_RC
+        assert lwalk.end_state == STATES.DECISION_BKW
         print('Hash:', graph.hash(sequence[S:S+ksize]))
         assert lwalk.tail() == graph.hash(branch[:ksize])
         assert rwalk.end_state == STATES.STOP_FWD

--- a/tests/test_ukhs.py
+++ b/tests/test_ukhs.py
@@ -10,17 +10,17 @@
 import pytest
 from .utils import *
 from boink import libboink
-from boink.hashing import (FwdRollingShifter, CanRollingShifter, UKHS)
+from boink.hashing import (FwdLemireShifter, CanLemireShifter, UKHS)
 
 
 @using(ksize=[21,31,41])
 def test_ukhs_query(ksize):
-    utype = UKHS[FwdRollingShifter]
+    utype = UKHS[FwdLemireShifter]
     ukhs = utype.load(ksize, 7)
     unikmers = utype.parse_unikmers(ksize, 7)
 
     for i, kmer in enumerate(unikmers):
-        uhash = FwdRollingShifter.hash(kmer, 7)
+        uhash = FwdLemireShifter.hash(kmer, 7)
         result = ukhs.query(uhash).value()
 
         assert uhash == result.value

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ from boink.hashing import types as hashing_types
 from boink.utils import check_trait, pretty_repr
 from boink.storage import _types as storage_types
 
-from boink.hashing import (FwdRollingShifter, CanRollingShifter,
+from boink.hashing import (FwdLemireShifter, CanLemireShifter,
                            FwdUnikmerShifter, CanUnikmerShifter,
                            UKHS)
 
@@ -32,7 +32,7 @@ def storage_type(request):
     return _storage_type, params
 
 
-@pytest.fixture(params=[FwdRollingShifter, CanRollingShifter,
+@pytest.fixture(params=[FwdLemireShifter, CanLemireShifter,
                         FwdUnikmerShifter, CanUnikmerShifter],
                 ids=lambda t: pretty_repr(t))
 def hasher_type(request, ksize):
@@ -62,7 +62,7 @@ def store(storage_type):
 
 @pytest.fixture
 def partitioned_graph(store, ksize):
-    ukhs = UKHS[FwdRollingShifter].load(ksize, 7)
+    ukhs = UKHS[FwdLemireShifter].load(ksize, 7)
     pstore = std.make_shared[libboink.storage.PartitionedStorage[type(store)]](ukhs.n_hashes(),
                                                                                store)
     graph = std.make_shared[libboink.PdBG[type(store), FwdUnikmerShifter]](ksize, 7,


### PR DESCRIPTION
Contains an example notebook demonstrating traversing around the dBG and explaining the Hierarchy of Hashers. Also makes name-changes for user clarity: all `Model` classes are now just `Hash`, `Kmer`, `Canonical`, etc; and all references to RollingHashShifter etc now refer to LemireHashShifter etc. It also makes a minor tweak to the traversal state names to make them more clear.